### PR TITLE
Add St. Helens, Knowsley, Sefton and Wirral and tags for Liverpool

### DIFF
--- a/lib/uk_planning_scraper/authorities.csv
+++ b/lib/uk_planning_scraper/authorities.csv
@@ -63,6 +63,7 @@ St. Helens,https://publicaccess.sthelens.gov.uk/online-applications/search.do?ac
 Knowsley,https://planapp.knowsley.gov.uk/online-applications/search.do?action=advanced,england,merseyside,liverpoolcityregion
 Sefton,https://pa.sefton.gov.uk/online-applications/search.do?action=advanced,england,merseyside,liverpoolcityregion
 Wirral,https://planning.wirral.gov.uk/online-applications/search.do?action=advanced,england,merseyside,liverpoolcityregion
+Halton,https://webapp.halton.gov.uk/planningapps/,england,cheshire,liverpoolcityregion
 Sheffield,https://planningapps.sheffield.gov.uk/online-applications/search.do?action=advanced,england
 Wakefield,https://planning.wakefield.gov.uk/online-applications/search.do?action=advanced,england
 South Downs,https://planningpublicaccess.southdowns.gov.uk/online-applications/search.do?action=advanced,nationalparks,england

--- a/lib/uk_planning_scraper/authorities.csv
+++ b/lib/uk_planning_scraper/authorities.csv
@@ -58,7 +58,11 @@ Bristol,https://planningonline.bristol.gov.uk/online-applications/search.do?acti
 Cardiff,https://planningonline.cardiff.gov.uk/online-applications/search.do?action=advanced,wales
 Epsom and Ewell,http://eplanning.epsom-ewell.gov.uk/online-applications/search.do?action=advanced,surrey,england
 Leeds,https://publicaccess.leeds.gov.uk/online-applications/search.do?action=advanced,england
-Liverpool,http://northgate.liverpool.gov.uk/PlanningExplorer17/GeneralSearch.aspx,england
+Liverpool,http://northgate.liverpool.gov.uk/PlanningExplorer17/GeneralSearch.aspx,england,merseyside,liverpoolcityregion
+St. Helens,https://publicaccess.sthelens.gov.uk/online-applications/search.do?action=advanced,england,merseyside,liverpoolcityregion
+Knowsley,https://planapp.knowsley.gov.uk/online-applications/search.do?action=advanced,england,merseyside,liverpoolcityregion
+Sefton,https://pa.sefton.gov.uk/online-applications/search.do?action=advanced,england,merseyside,liverpoolcityregion
+Wirral,https://planning.wirral.gov.uk/online-applications/search.do?action=advanced,england,merseyside,liverpoolcityregion
 Sheffield,https://planningapps.sheffield.gov.uk/online-applications/search.do?action=advanced,england
 Wakefield,https://planning.wakefield.gov.uk/online-applications/search.do?action=advanced,england
 South Downs,https://planningpublicaccess.southdowns.gov.uk/online-applications/search.do?action=advanced,nationalparks,england

--- a/spec/authority_spec.rb
+++ b/spec/authority_spec.rb
@@ -28,7 +28,7 @@ describe UKPlanningScraper::Authority do
     let(:all) { described_class.all }
 
     it 'returns all authorities' do
-      expect(all.count).to eq(66)
+      expect(all.count).to eq(71)
     end
 
     it 'returns a list of authorities' do


### PR DESCRIPTION
Add all the councils in Liverpool City Region that the scraper supports.  Have tested them all with a quick check of the last 7 days using the single_authority_planning_applications and successfully got results back from each.

(Halton is missing from the set-of-councils-in-LCR as its planning portal doesn't seem to be supported)