### PR TITLE
Update authorities.csv

### DIFF
--- a/lib/uk_planning_scraper/authorities.csv
+++ b/lib/uk_planning_scraper/authorities.csv
@@ -49,7 +49,7 @@ London Legacy Development Corporation,http://planningregister.londonlegacy.co.uk
 Manchester,https://pa.manchester.gov.uk/online-applications/search.do?action=advanced,england,greatermanchester
 Merton,http://planning.merton.gov.uk/Northgate/PlanningExplorerAA/GeneralSearch.aspx,london,outerlondon,southlondon,england,londonboroughs
 Newham,https://pa.newham.gov.uk/online-applications/search.do?action=advanced,londonboroughs,london,londonboroughs
-Northern Ireland,http://epicpublic.planningni.gov.uk/publicaccess/search.do?action=advanced&searchType=Application,nireland,belfast
+Northern Ireland,http://epicpublic.planningni.gov.uk/publicaccess/search.do?action=advanced&searchType=Application,northernireland,belfast
 Nottingham,http://publicaccess.nottinghamcity.gov.uk/online-applications/search.do?action=advanced,nottingham,eastmidlands,england
 Old Oak and Park Royal Development Corporation,http://planningregister.opdc.london.gov.uk/swift/apas/run/wphappcriteria.display,london,developmentcorporations,londondevelopmentcorporations
 Oldham,http://planningpa.oldham.gov.uk/online-applications/search.do?action=advanced,england,greatermanchester

--- a/lib/uk_planning_scraper/authorities.csv
+++ b/lib/uk_planning_scraper/authorities.csv
@@ -49,6 +49,7 @@ London Legacy Development Corporation,http://planningregister.londonlegacy.co.uk
 Manchester,https://pa.manchester.gov.uk/online-applications/search.do?action=advanced,england,greatermanchester
 Merton,http://planning.merton.gov.uk/Northgate/PlanningExplorerAA/GeneralSearch.aspx,london,outerlondon,southlondon,england,londonboroughs
 Newham,https://pa.newham.gov.uk/online-applications/search.do?action=advanced,londonboroughs,london,londonboroughs
+Northern Ireland,http://epicpublic.planningni.gov.uk/publicaccess/search.do?action=advanced&searchType=Application,nireland,belfast
 Nottingham,http://publicaccess.nottinghamcity.gov.uk/online-applications/search.do?action=advanced,nottingham,eastmidlands,england
 Old Oak and Park Royal Development Corporation,http://planningregister.opdc.london.gov.uk/swift/apas/run/wphappcriteria.display,london,developmentcorporations,londondevelopmentcorporations
 Oldham,http://planningpa.oldham.gov.uk/online-applications/search.do?action=advanced,england,greatermanchester

--- a/spec/authority_spec.rb
+++ b/spec/authority_spec.rb
@@ -28,7 +28,7 @@ describe UKPlanningScraper::Authority do
     let(:all) { described_class.all }
 
     it 'returns all authorities' do
-      expect(all.count).to eq(74)
+      expect(all.count).to eq(75)
     end
 
     it 'returns a list of authorities' do


### PR DESCRIPTION
Added N. Ireland from their centralised site - I haven't added all authorities as it's a long list and I wasn't sure it could cope with it. At the moment only Belfast has applications. 

The councils are listed below and can't be added separately, they all use this site for planning applications.
    Causeway Coast and Glens
    Mid and East Antrim
    Antrim and Newtownabbey
    Belfast
    Lisburn and Castlereagh City Council
    Ards and North Down
    Newry, Mourne and Down
    Armagh, Banbridge and Craigavon
    Mid Ulster
    Fermanagh and Omagh
    Derry City and Strabane District