### PR TITLE
Add ability to scrape property details

### DIFF
--- a/lib/uk_planning_scraper.rb
+++ b/lib/uk_planning_scraper.rb
@@ -2,6 +2,7 @@ require "uk_planning_scraper/version"
 require "uk_planning_scraper/authority"
 require "uk_planning_scraper/authority_scrape_params"
 require "uk_planning_scraper/application"
+require "uk_planning_scraper/property"
 require 'uk_planning_scraper/idox'
 require 'uk_planning_scraper/northgate'
 require 'logger'

--- a/lib/uk_planning_scraper/application.rb
+++ b/lib/uk_planning_scraper/application.rb
@@ -37,7 +37,7 @@ module UKPlanningScraper
         appeal_decision: @appeal_decision
       }
     end
-    
+
     def valid?
       return true if @authority_name && @council_reference && @info_url
       false

--- a/lib/uk_planning_scraper/application.rb
+++ b/lib/uk_planning_scraper/application.rb
@@ -16,6 +16,10 @@ module UKPlanningScraper
     attr_accessor :date_decision
     attr_accessor :appeal_status
     attr_accessor :appeal_decision
+    attr_accessor :property_count
+    attr_accessor :property_url
+    attr_accessor :property_detail_urls
+    attr_accessor :properties
 
     def to_hash
       {
@@ -34,7 +38,10 @@ module UKPlanningScraper
         documents_url: @documents_url,
         alternative_reference: @alternative_reference,
         appeal_status: @appeal_status,
-        appeal_decision: @appeal_decision
+        appeal_decision: @appeal_decision,
+        property_count: @property_count,
+        property_detail_urls: @property_detail_urls,
+        properties: @properties
       }
     end
 

--- a/lib/uk_planning_scraper/application.rb
+++ b/lib/uk_planning_scraper/application.rb
@@ -22,7 +22,7 @@ module UKPlanningScraper
     attr_accessor :properties
 
     def to_hash
-      {
+      base = {
         scraped_at: @scraped_at,
         authority_name: @authority_name,
         council_reference: @council_reference,
@@ -39,10 +39,21 @@ module UKPlanningScraper
         alternative_reference: @alternative_reference,
         appeal_status: @appeal_status,
         appeal_decision: @appeal_decision,
-        property_count: @property_count,
-        property_detail_urls: @property_detail_urls,
-        properties: @properties
+        property_count: @property_count
       }
+
+      @property_detail_urls.each_with_index do |url, idx|
+        base["property_detail_url_#{idx + 1}".to_sym] = url
+      end if @property_detail_urls
+
+      @properties.each_with_index do |property, idx|
+        property_hash = property.to_hash
+        property_hash.transform_keys! { |k| "property_#{idx + 1}_#{k}".to_sym }
+
+        base.merge!(property_hash)
+      end if @properties
+
+      base
     end
 
     def valid?

--- a/lib/uk_planning_scraper/authority.rb
+++ b/lib/uk_planning_scraper/authority.rb
@@ -3,7 +3,7 @@ require 'csv'
 module UKPlanningScraper
   class Authority
     attr_reader :name, :url
-    
+
     @@authorities = []
 
     def initialize(name, url)
@@ -31,7 +31,7 @@ module UKPlanningScraper
         raise SystemNotSupported.new("Planning system not supported for \
           #{@name} at URL: #{@url}")
       end
-      
+
       # Post processing
       @applications.each do |app|
         app.authority_name = @name
@@ -41,32 +41,32 @@ module UKPlanningScraper
       output = []
       # FIXME - silently ignores invalid apps. How should we handle them?
       @applications.each { |app| output << app.to_hash if app.valid? }
-      
+
       # Reset so that old params don't get used for new scrapes
       clear_scrape_params
-      
+
       output  # Single point of successful exit
     end
-    
+
     def tags
       @tags.sort
     end
-    
+
     # Add multiple tags to existing tags
     def add_tags(tags)
       tags.each { |t| add_tag(t) }
     end
-    
+
     # Add a single tag to existing tags
     def add_tag(tag)
       clean_tag = tag.strip.downcase.gsub(' ', '')
       @tags << clean_tag unless tagged?(clean_tag) # prevent duplicates
     end
-    
+
     def tagged?(tag)
       @tags.include?(tag)
     end
-    
+
     def system
       if @url.match(/search\.do\?action=advanced/i)
         'idox'
@@ -84,18 +84,18 @@ module UKPlanningScraper
     def self.all
       @@authorities
     end
-    
+
     # List all the tags in use
     def self.tags
       tags = []
       @@authorities.each { |a| tags << a.tags }
       tags.flatten.uniq.sort
     end
-    
+
     def self.named(name)
       authority = @@authorities.find { |a| name == a.name }
       raise AuthorityNotFound if authority.nil?
-      authority 
+      authority
     end
 
     # Tagged x
@@ -125,11 +125,11 @@ module UKPlanningScraper
       CSV.foreach(File.join(File.dirname(__dir__), 'uk_planning_scraper', \
           'authorities.csv'), :headers => true) do |line|
         auth = Authority.new(line['authority_name'], line['url'])
-        
+
         if line['tags']
           auth.add_tags(line['tags'].split(/\s+/))
         end
-        
+
         auth.add_tag(auth.system)
         @@authorities << auth
       end

--- a/lib/uk_planning_scraper/authority_scrape_params.rb
+++ b/lib/uk_planning_scraper/authority_scrape_params.rb
@@ -4,7 +4,7 @@ module UKPlanningScraper
   class Authority
     # Parameter methods for Authority#scrape
     # Desgined to be method chained, eg:
-    # 
+    #
     # applications = UKPlanningScraper::Authority.named("Barnet"). \
     # development_type("Q22").keywords("illuminat"). \
     # validated_days(30).scrape
@@ -17,7 +17,7 @@ module UKPlanningScraper
       unless n > 0
         raise ArgumentError.new("validated_days must be greater than 0")
       end
-      
+
       validated_from(Date.today - (n - 1))
       validated_to(Date.today)
       self
@@ -31,7 +31,7 @@ module UKPlanningScraper
       unless n > 0
         raise ArgumentError.new("received_days must be greater than 0")
       end
-      
+
       received_from(Date.today - (n - 1))
       received_to(Date.today)
       self
@@ -45,18 +45,18 @@ module UKPlanningScraper
       unless n > 0
         raise ArgumentError.new("decided_days must be greater than 0")
       end
-      
+
       decided_from(Date.today - (n - 1))
       decided_to(Date.today)
       self
     end
-    
+
     def applicant_name(s)
       unless system == 'idox'
         raise NoMethodError.new("applicant_name is only implemented for Idox. \
           This authority (#{@name}) is #{system.capitalize}.")
       end
-      
+
       check_class(s, String)
       @scrape_params[:applicant_name] = s.strip
       self
@@ -67,7 +67,7 @@ module UKPlanningScraper
         raise NoMethodError.new("application_type is only implemented for \
           Idox. This authority (#{@name}) is #{system.capitalize}.")
       end
-      
+
       check_class(s, String)
       @scrape_params[:application_type] = s.strip
       self
@@ -78,14 +78,14 @@ module UKPlanningScraper
         raise NoMethodError.new("development_type is only implemented for \
           Idox. This authority (#{@name}) is #{system.capitalize}.")
       end
-      
+
       check_class(s, String)
       @scrape_params[:development_type] = s.strip
       self
     end
 
     private
-    
+
     # Handle the simple params with this
     def method_missing(method_name, *args)
       sc_params = {
@@ -97,18 +97,18 @@ module UKPlanningScraper
         decided_to: Date,
         keywords: String
       }
-      
+
       value = args[0]
-      
+
       if sc_params[method_name]
         check_class(value, sc_params[method_name], method_name.to_s)
         value.strip! if value.class == String
-        
+
         if value.class == Date && value > Date.today
           raise ArgumentError.new("#{method_name} can't be a date in the " + \
             "future (#{value.to_s})")
         end
-        
+
         @scrape_params[method_name] = value
         self
       else
@@ -119,7 +119,7 @@ module UKPlanningScraper
     def clear_scrape_params
       @scrape_params = {}
     end
-    
+
     # https://stackoverflow.com/questions/5100299/how-to-get-the-name-of-the-calling-method
     def check_class(
       param_value,

--- a/lib/uk_planning_scraper/authority_scrape_params.rb
+++ b/lib/uk_planning_scraper/authority_scrape_params.rb
@@ -84,6 +84,16 @@ module UKPlanningScraper
       self
     end
 
+    def include_property
+      unless system == 'idox'
+        raise NoMethodError.new("include_property is only implemented for \
+          Idox. This authority (#{@name}) is #{system.capitalize}.")
+      end
+
+      @scrape_params[:include_property] = true
+      self
+    end
+
     private
 
     # Handle the simple params with this

--- a/lib/uk_planning_scraper/idox.rb
+++ b/lib/uk_planning_scraper/idox.rb
@@ -129,6 +129,8 @@ module UKPlanningScraper
         puts "#{i + 1} of #{apps.size}"
 
         parse_info_url(app) if app.info_url
+
+        next unless params[:include_property]
         parse_property_url(app) if app.property_url
         parse_property_detail_urls(app) if app.property_detail_urls
       end # scrape summary tab for apps

--- a/lib/uk_planning_scraper/idox.rb
+++ b/lib/uk_planning_scraper/idox.rb
@@ -4,13 +4,20 @@ require 'pp'
 module UKPlanningScraper
   class Authority
     private
+
+    def base_url
+      @base_url ||= @url.match(/(https?:\/\/.+?)\//)[1]
+    end
+
+    def agent
+      @agent ||= Mechanize.new
+    end
+
     def scrape_idox(params, options)
       puts "Using Idox scraper."
-      base_url = @url.match(/(https?:\/\/.+?)\//)[1]
 
       apps = []
 
-      agent = Mechanize.new
       puts "Getting: #{@url}"
       page = agent.get(@url) # load the search form page
 
@@ -111,72 +118,77 @@ module UKPlanningScraper
       apps.each_with_index do |app, i|
         sleep options[:delay]
         puts "#{i + 1} of #{apps.size}: #{app.info_url}"
-        res = agent.get(app.info_url)
 
-        if res.code == '200' # That's a String not an Integer, ffs
-          # Parse the summary tab for this app
-
-          app.scraped_at = Time.now
-
-          # The Documents tab doesn't show if there are no documents (we get li.nodocuments instead)
-          # Bradford has #tab_documents but without the document count on it
-          app.documents_count = 0
-
-          if documents_link = res.at('.associateddocument a')
-            if documents_link.inner_text.match(/\d+/)
-              app.documents_count = documents_link.inner_text.match(/\d+/)[0].to_i
-              app.documents_url = base_url + documents_link[:href]
-            end
-          elsif documents_link = res.at('#tab_documents')
-            if documents_link.inner_text.match(/\d+/)
-              app.documents_count = documents_link.inner_text.match(/\d+/)[0].to_i
-              app.documents_url = base_url + documents_link[:href]
-            end
-          end
-
-          # We need to find values in the table by using the th labels.
-          # The row indexes/positions change from site to site (or even app to app) so we can't rely on that.
-
-          res.search('#simpleDetailsTable tr').each do |row|
-            key = row.at('th').inner_text.strip
-            value = row.at('td').inner_text.strip
-
-            case key
-              when 'Reference'
-                app.council_reference = value
-              when 'Alternative Reference'
-                app.alternative_reference = value unless value.empty?
-              when 'Planning Portal Reference'
-                app.alternative_reference = value unless value.empty?
-              when 'Application Received'
-                app.date_received = Date.parse(value) if value.match(/\d/)
-              when 'Application Registered'
-                app.date_received = Date.parse(value) if value.match(/\d/)
-              when 'Application Validated'
-                app.date_validated = Date.parse(value) if value.match(/\d/)
-              when 'Address'
-                app.address = value unless value.empty?
-              when 'Proposal'
-                app.description = value unless value.empty?
-              when 'Status'
-                app.status = value unless value.empty?
-              when 'Decision'
-                app.decision = value unless value.empty?
-              when 'Decision Issued Date'
-                app.date_decision = Date.parse(value) if value.match(/\d/)
-              when 'Appeal Status'
-                app.appeal_status = value unless value.empty?
-              when 'Appeal Decision'
-                app.appeal_decision = value unless value.empty?
-              else
-                puts "Error: key '#{key}' not found"
-            end # case
-          end # each row
-        else
-          puts "Error: HTTP #{res.code}"
-        end # if
+        parse_info_url(app) if app.info_url
       end # scrape summary tab for apps
       apps
     end # scrape_idox
+
+    def parse_info_url(app)
+      res = agent.get(app.info_url)
+
+      if res.code == '200' # That's a String not an Integer, ffs
+        # Parse the summary tab for this app
+
+        app.scraped_at = Time.now
+
+        # The Documents tab doesn't show if there are no documents (we get li.nodocuments instead)
+        # Bradford has #tab_documents but without the document count on it
+        app.documents_count = 0
+
+        if documents_link = res.at('.associateddocument a')
+          if documents_link.inner_text.match(/\d+/)
+            app.documents_count = documents_link.inner_text.match(/\d+/)[0].to_i
+            app.documents_url = base_url + documents_link[:href]
+          end
+        elsif documents_link = res.at('#tab_documents')
+          if documents_link.inner_text.match(/\d+/)
+            app.documents_count = documents_link.inner_text.match(/\d+/)[0].to_i
+            app.documents_url = base_url + documents_link[:href]
+          end
+        end
+
+        # We need to find values in the table by using the th labels.
+        # The row indexes/positions change from site to site (or even app to app) so we can't rely on that.
+
+        res.search('#simpleDetailsTable tr').each do |row|
+          key = row.at('th').inner_text.strip
+          value = row.at('td').inner_text.strip
+
+          case key
+            when 'Reference'
+              app.council_reference = value
+            when 'Alternative Reference'
+              app.alternative_reference = value unless value.empty?
+            when 'Planning Portal Reference'
+              app.alternative_reference = value unless value.empty?
+            when 'Application Received'
+              app.date_received = Date.parse(value) if value.match(/\d/)
+            when 'Application Registered'
+              app.date_received = Date.parse(value) if value.match(/\d/)
+            when 'Application Validated'
+              app.date_validated = Date.parse(value) if value.match(/\d/)
+            when 'Address'
+              app.address = value unless value.empty?
+            when 'Proposal'
+              app.description = value unless value.empty?
+            when 'Status'
+              app.status = value unless value.empty?
+            when 'Decision'
+              app.decision = value unless value.empty?
+            when 'Decision Issued Date'
+              app.date_decision = Date.parse(value) if value.match(/\d/)
+            when 'Appeal Status'
+              app.appeal_status = value unless value.empty?
+            when 'Appeal Decision'
+              app.appeal_decision = value unless value.empty?
+            else
+              puts "Error: key '#{key}' not found"
+          end # case
+        end # each row
+      else
+        puts "Error: HTTP #{res.code}"
+      end # if
+    end
   end # class
 end

--- a/lib/uk_planning_scraper/idox.rb
+++ b/lib/uk_planning_scraper/idox.rb
@@ -213,7 +213,9 @@ module UKPlanningScraper
       app.property_detail_urls = []
 
       get(app.property_url) do |res|
-        res.search('#Property li a').each do |property_link|
+        res.search('#Property li a').each_with_index do |property_link, index|
+          break if index >= 10
+
           app.property_detail_urls << base_url + property_link[:href]
         end
       end

--- a/lib/uk_planning_scraper/northgate.rb
+++ b/lib/uk_planning_scraper/northgate.rb
@@ -8,10 +8,10 @@ module UKPlanningScraper
     def scrape_northgate(params, options)
       puts "Using Northgate scraper."
       base_url = @url.match(/(https?:\/\/.+?)\//)[1]
-      
+
       # Remove 'generalsearch.aspx' from the end and add '/Generic/' - case sensitive?
       generic_url = @url.match(/.+\//)[0] + 'Generic/'
-      
+
       apps = []
 
       $stdout.sync = true # Flush output buffer after every write so log messages appear immediately.

--- a/lib/uk_planning_scraper/property.rb
+++ b/lib/uk_planning_scraper/property.rb
@@ -1,0 +1,30 @@
+module UKPlanningScraper
+  class Property
+    attr_accessor :uprn
+    attr_accessor :address
+    attr_accessor :number
+    attr_accessor :street
+    attr_accessor :town
+    attr_accessor :postcode
+    attr_accessor :ward
+    attr_accessor :parish
+
+    def to_hash
+      {
+        uprn: @uprn,
+        address: @address,
+        number: @number,
+        street: @street,
+        town: @town,
+        postcode: @postcode,
+        ward: @ward,
+        parish: @parish
+      }
+    end
+
+    def valid?
+      return true if @uprn
+      false
+    end
+  end
+end

--- a/spec/property_details_spec.rb
+++ b/spec/property_details_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe UKPlanningScraper::Authority do
+
+  describe '#include_property' do
+
+    let(:scraper) { UKPlanningScraper::Authority.named(authority_name) }
+
+    context 'for 2 days  with property details' do
+      let(:authority_name) { 'Cardiff' }
+
+      it 'returns apps' do
+        apps = VCR.use_cassette("#{self.class.description}") {
+          scraper.include_property
+                 .decided_from(Date.new(2019, 4, 8))
+                 .decided_to(Date.new(2019, 4, 9))
+                 .scrape(delay: 0)
+        }
+        pp apps
+      end
+    end
+
+  end
+
+end

--- a/spec/vcr_cassettes/for_2_days_with_property_details.yml
+++ b/spec/vcr_cassettes/for_2_days_with_property_details.yml
@@ -1,0 +1,7183 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://planningonline.cardiff.gov.uk/online-applications/search.do?action=advanced
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip,deflate,identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mechanize/2.7.6 Ruby/2.6.2p47 (http://github.com/sparklemotion/mechanize/)
+      Accept-Charset:
+      - ISO-8859-1,utf-8;q=0.7,*;q=0.7
+      Accept-Language:
+      - en-us,en;q=0.5
+      Host:
+      - planningonline.cardiff.gov.uk
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '300'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - text/html; charset=UTF-8
+      Expires:
+      - Mon, 15 Apr 2019 11:14:04 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ua-Compatible:
+      - IE=edge
+      Server:
+      - Apache
+      Set-Cookie:
+      - JSESSIONID=ss9pKoHL32yHmhJQONSykek96zXCSSZ75skxJ5v1.vmidoxweblve; path=/;
+        HttpOnly
+      - WSLang-CFC001=en; expires=Mon, 15-Apr-2069 11:14:03 GMT; path=/; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 15 Apr 2019 11:14:04 GMT
+      Content-Length:
+      - '37801'
+    body:
+      encoding: UTF-8
+      string: "\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n<!DOCTYPE
+        html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\r\n<html
+        lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\r\n<head>\r\n\t\r\n\t<!--
+        #BeginEditable \"doctitle\" -->\r\n<title>Applications Search </title>\r\n<!--
+        #EndEditable -->\r\n    <!-- #BeginEditable \"metatags\" --><!-- #EndEditable
+        -->\r\n\t\r\n    <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
+        />\r\n\t\r\n\t<!-- Customer metatags -->\r\n\t\r\n\t\r\n\t<!-- Favicon link
+        -->\r\n    <link rel=\"icon\" href=\"/online-applications-skin/images/cardiff/favicon.ico\"
+        type=\"image/x-icon\" />\r\n\t\r\n    <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/screen.css\"
+        type=\"text/css\" media=\"screen,projection\" />\r\n    <link rel=\"stylesheet\"
+        href=\"/online-applications-skin/styles/theme1.css\" type=\"text/css\"/>    \r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/print.css\"
+        type=\"text/css\" media=\"print\" />\r\n\t\r\n    <script type=\"text/javascript\"
+        src=\"/online-applications-skin/scripts/jquery.min.js\"></script>\r\n    <script
+        type=\"text/javascript\" src=\"/online-applications-skin/scripts/jquery.toolbar.idox.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/common.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/checkbox.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/amplify.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/createCommentCookie.js\"></script>\r\n
+        \       \r\n\t<!-- Customer Analytics Script -->\r\n\t\r\n\t\r\n    <script
+        type=\"text/javascript\">\r\n    \t$('html').addClass('js');\r\n    \t$(document).ready(function(){\r\n
+        \   \t\t$('.main#apply>span:first-child').attr('tabindex', '0')\r\n    \t});\r\n
+        \   </script>\r\n    \r\n    <!-- #BeginEditable \"mobile\" --><!-- #EndEditable
+        -->\r\n    <!-- #BeginEditable \"head\" -->\r\n\t<script type=\"text/javascript\"
+        src=\"/online-applications-skin/scripts/calendar.popup.min.js\"></script>\r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/scripts/calendar.css\"
+        type=\"text/css\" media=\"screen,projection\" />\r\n    \r\n    <script type=\"text/javascript\"><!--//--><![CDATA[//><!--\r\n
+        \       var errMsg=\"\";\r\n        try {\r\n            var calendar = new
+        CalendarPopup(\"calendarDiv\");\r\n        }\r\n        catch (err)\r\n        {
+        errMsg=\"There was an error on this page.\\n\";\r\n            errMsg+=\"Please
+        check the Java Script settings of your browser or \\n\";\r\n            errMsg+=\"enter
+        date manually with format dd/mm/yyyy.\\n\";\r\n            errMsg+=\"Click
+        OK to continue.\\n\\n\";\r\n            alert(errMsg);\r\n        }//--><!]]>\r\n
+        \   </script>\r\n<!-- #EndEditable -->\r\n    <!-- #BeginEditable \"webapp\"
+        -->\r\n    \r\n        \r\n    \r\n<!-- #EndEditable -->\r\n\r\n</head>\r\n<body>\r\n\r\n
+        \   <a href=\"#pageheading\" class=\"sr-only\">Skip to main content</a>\r\n\r\n
+        \   <!-- IDOX PA START -->\r\n    <div id=\"idox\">\r\n        <div id=\"pa\">\r\n\t\t\t<div
+        id=\"header\"><!-- Selector: Selector 1 -->\r\n<style>\r\n#langStyle{float:right;
+        margin-top: 10px; margin-right: 30px; background:transparent; font-size:13px;
+        cursor:pointer; border:1px solid #fff !important;border-radius:2px; z-index:999;
+        background-color: #fff; padding:2px;}\r\n#langStyle:hover{text-decoration:
+        underline;}</style>\r\n<div>\r\n\r\n<!--CYS--><a id=\"langStyle\" href=\"/online-applications/search.do?action=advanced&lang=CY\">Cymraeg</a><!--CYE-->\r\n</div>\r\n\t\t\t\t<div
+        class=\"container\">\r\n\t\t\t\t\t<div id=\"logo\"><a href=\"https://www.cardiff.gov.uk/\"
+        title=\"Cardiff Council home page\"><img src=\"/online-applications-skin/images/cardiff/logo.png\"
+        alt=\"Council logo\" /><span class=\"sr-only\">Cardiff Council</span></a></div>\r\n\t\t\t\t\t<div
+        id=\"headertitle\"><span></span></div>\r\n\t\t\t\t\t<div class=\"clear\"></div>\r\n\t\t\t\t</div>\t\r\n\t\t\t</div>\r\n\t\t\t<div
+        id=\"breadcrumbs\" class=\"container\">\r\n\t\t\t\t<ul>\r\n\t\t\t\t\t\r\n\t\t\t\t</ul>\r\n\t\t\t</div>\r\n
+        \           <div class=\"container\">\r\n       \t\t\t<div id=\"toolbar\"
+        class=\"nojs\">\r\n                    <ul>\t\r\n                        <li
+        id=\"search\" class=\"main\"><span tabindex=\"0\">Search&nbsp;</span><span
+        class=\"caret\"></span>\r\n   \t\t\t\t\t\t\t<ul>\t\r\n\t\t\t\t\t\t\t\t<!--
+        #BeginLibraryItem \"/Library/searchModulesNavItems.lbi\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \       \r\n            <li id=\"planLinks\">\r\n                <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\"
+        >\r\n                    <span>Planning</span>\r\n                </a>\r\n
+        \               <ul>\r\n                    <li id=\"planBasicSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\">\r\n
+        \                           Simple Search\r\n                        </a>\r\n
+        \                   </li>\r\n\r\n                    <li id=\"planAdvancedSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=advanced&amp;searchType=Application\">\r\n
+        \                           Advanced\r\n                        </a>\r\n                    </li>\r\n
+        \                   <li id=\"planListSearch\">\r\n                        <a
+        href=\"/online-applications/search.do?action=weeklyList&amp;searchType=Application\">\r\n
+        \                           Weekly/Monthly Lists\r\n                        </a>\r\n
+        \                   </li>\r\n                    <li id=\"planPropertySearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=property&amp;type=custom\">\r\n
+        \                           Property Search\r\n                        </a>\r\n
+        \                   </li>\r\n\t\t\t\t\t\r\n                    \r\n\t\t\t\t\t\r\n
+        \               </ul>\r\n            </li>\r\n        \r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        <!-- #EndLibraryItem -->\r\n                        \t</ul>\r\n\t\t\t\t\t\t</li>\r\n
+        \                       <!-- #BeginEditable \"applicationForms\" -->\n\n\n\n\n\n
+        \  \n<!-- #EndEditable -->   \t\t\t\t\r\n                        <li id=\"myprofile\"
+        class=\"main\"><span tabindex=\"0\">My Profile&nbsp;</span><span class=\"caret\"></span>\r\n
+        \                           <ul>\r\n                              <!-- #BeginLibraryItem
+        \"/Library/consulteeInTrayNavItem.lbi\" -->\n\n\n\n\n\n\n    <!-- #EndLibraryItem
+        -->\r\n                                <li><a href=\"/online-applications/registered/displayUserDetails.do\">Profile
+        Details</a></li>\r\n                                <li><a href=\"/online-applications/registered/savedSearch.do?action=display\">Saved
+        Searches</a></li>\r\n                                <li><a href=\"/online-applications/registered/userAdmin.do?action=showNotifiedApplications\">Notified
+        Applications</a></li>\r\n                                <li><a href=\"/online-applications/registered/trackedApplication.do?action=display\">Tracked
+        Applications</a></li>\r\n                                <!-- #BeginEditable
+        \"formSubmissions\" -->\n\n\n\n\n\n\n\n\n<!-- #EndEditable -->    \t\r\n                            </ul>\r\n
+        \                       </li>\r\n                        <li id=\"loginLink\"
+        class=\"main\"><!-- #BeginEditable \"loginlogout\" -->\n\n\n\n\n\n\n\n\n\n\n\t<a
+        href=\"/online-applications/registered/userAdmin.do\">Login</a>\n<!-- #EndEditable
+        --></li>\r\n                        <!-- #BeginEditable \"register\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \  \r\n\r\n\r\n\t<li id=\"register\">\r\n        <a href=\"/online-applications/registrationWizard.do?action=start\">Register</a>\r\n\t</li>\r\n\r\n<!--
+        #EndEditable -->\r\n                        <!-- #BeginLibraryItem \"/Library/applyOnlineNavItems.lbi\"
+        -->\r\n\r\n\r\n\r\n\r\n\r\n<!-- #EndLibraryItem -->\r\n                    </ul>\r\n
+        \   \t\t\t</div>\r\n\r\n    \t\t\t<!-- #BeginEditable \"headlinenews\" --><!--
+        #EndEditable -->\r\n                 \r\n                <div id=\"pageheading\">\r\n
+        \                   <h1><strong>Planning</strong>&nbsp;&ndash;&nbsp;<!-- #BeginEditable
+        \"pageheading\" -->Applications Search <!-- #EndEditable --></h1>\r\n                    <!--
+        #BeginEditable \"helplink\" -->\r\n<p class=\"pagehelp\">\r\n\t<a title=\"Help
+        with this page (opens in a new window)\" rel=\"external\" target=\"_blank\"
+        href=\"/online-applications/help/pagehelp/advancedSearchapplication.htm\">\r\n\t\tHelp
+        with this page\r\n\t<span> (opens in a new window)</span>\r\n\t</a>\r\n</p>\r\n<!--
+        #EndEditable -->\r\n                </div>\r\n                \r\n                <!--
+        START WAM CONTENT -->\r\n                <div class=\"content\">\r\n                    <!--
+        #BeginEditable \"errormsg\" -->\r\n    \r\n    \r\n\r\n    \r\n    \r\n\r\n<!--
+        #EndEditable -->\r\n                    <!-- #BeginEditable \"pagehead\" -->\r\n<p>Search
+        \ for Planning Applications, Appeals and Enforcements by matching at least
+        one search option in the form below.</p>\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabs\" -->\r\n    \r\n        \r\n        \r\n        \r\n
+        \   \r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \   \r\n\r\n\r\n<ul class=\"tabs\">\r\n\r\n    \r\n    <li>\r\n        <a
+        href=\"/online-applications/search.do?action=simple\" class=\"\"><span>Simple</span></a>\r\n
+        \   </li>\r\n\r\n    \r\n    <li>\r\n        <a href=\"/online-applications/search.do?action=advanced\"
+        class=\"active\"><span> Advanced</span></a>\r\n        \r\n            \r\n
+        \           <ul class=\"subtabs\">\r\n                \r\n                    <li>\r\n
+        \                       <a href=\"/online-applications/search.do?action=advanced&amp;searchType=Application\"
+        class=\"active\"><span> Applications</span></a>\r\n                    </li>\r\n
+        \               \r\n                    <li>\r\n                        <a
+        href=\"/online-applications/search.do?action=advanced&amp;searchType=Appeal\"
+        class=\"\"><span> Appeals</span></a>\r\n                    </li>\r\n                \r\n
+        \                   <li>\r\n                        <a href=\"/online-applications/search.do?action=advanced&amp;searchType=Enforcement\"
+        class=\"\"><span> Enforcements</span></a>\r\n                    </li>\r\n
+        \               \r\n            </ul>\r\n        \r\n    </li>\r\n\r\n    \r\n
+        \       \r\n        <li>\r\n            <a href=\"/online-applications/search.do?action=weeklyList\"
+        class=\"\"><span>Weekly/Monthly Lists</span></a>\r\n            \r\n        </li>\r\n
+        \   \r\n\r\n    \r\n    <li>\r\n        <a href=\"/online-applications/search.do?action=property&amp;type=custom\"
+        class=\"\"><span> Property</span></a>\r\n        \r\n    </li>\r\n\r\n    \r\n
+        \   \r\n\r\n</ul>\r\n\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabsubnav\" --><!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"pagebody\" -->\r\n\r\n\r\n\r\n    <div id=\"calendarDiv\"
+        style=\"position:absolute;visibility:hidden;background-color:white;\"></div>\r\n\r\n\r\n<div
+        class=\"tabcontainer\">\r\n<form name=\"searchCriteriaForm\" method=\"post\"
+        action=\"/online-applications/advancedSearchResults.do?action=firstPage\"
+        id=\"advancedSearchForm\">\r\n\r\n\r\n\t<h3>\r\n        Reference Numbers\r\n
+        \   </h3>\n\r\n\t<div id=\"referenceNumbers\">\r\n        <fieldset>\r\n            <legend>\r\n
+        \               Reference Numbers\r\n            </legend>\r\n\r\n            \r\n
+        \               <div class=\"reference\">\r\n                    <label for=\"reference\">\r\n
+        \                       Application Reference:\r\n                    </label>\r\n
+        \                   <input type=\"text\" name=\"searchCriteria.reference\"
+        maxlength=\"255\" autocomplete=\"off\" value=\"\" onblur=\"javascript:this.value=this.value.replace(/^\\s+|\\s+$/g,'')\"
+        onfocus=\"javascript:this.value=this.value.replace(/^\\s+|\\s+$/g,'')\" class=\"text\"
+        id=\"reference\" />\r\n                </div>\r\n            \r\n\r\n            \r\n
+        \               <div class=\"planningPortalReference\">\r\n                    <label
+        for=\"planningPortalReference\">\r\n                        Planning Portal
+        Reference:\r\n                    </label>\r\n                    <input type=\"text\"
+        name=\"searchCriteria.planningPortalReference\" maxlength=\"255\" autocomplete=\"off\"
+        value=\"\" onblur=\"javascript:this.value=this.value.replace(/^\\s+|\\s+$/g,'')\"
+        onfocus=\"javascript:this.value=this.value.replace(/^\\s+|\\s+$/g,'')\" class=\"text\"
+        id=\"planningPortalReference\" />\r\n                </div>\r\n            \r\n\r\n
+        \           \r\n                <div class=\"alternativeReference\">\r\n                    <label
+        for=\"alternativeReference\">\r\n                        Alternative Reference:\r\n
+        \                   </label>\r\n                    <input type=\"text\" name=\"searchCriteria.alternativeReference\"
+        maxlength=\"255\" autocomplete=\"off\" value=\"\" onblur=\"javascript:this.value=this.value.replace(/^\\s+|\\s+$/g,'')\"
+        onfocus=\"javascript:this.value=this.value.replace(/^\\s+|\\s+$/g,'')\" class=\"text\"
+        id=\"alternativeReference\" />\r\n                </div>\r\n            \r\n\r\n
+        \           \r\n\r\n            \r\n\r\n            \r\n\r\n            \r\n\r\n
+        \       </fieldset>\r\n    </div>\r\n\r\n\r\n\r\n    <h3>\r\n        Application
+        Details\r\n    </h3>\n\r\n    <div id=\"details\">\r\n        <fieldset>\r\n
+        \           <legend>\r\n                Application Details\r\n            </legend>\r\n\r\n
+        \           \r\n                <div class=\"description\">\r\n                    <label
+        for=\"description\">\r\n                        Description Keyword:\r\n                    </label>\r\n
+        \                   <input type=\"text\" name=\"searchCriteria.description\"
+        maxlength=\"255\" autocomplete=\"off\" value=\"\" onblur=\"javascript:this.value=this.value.replace(/^\\s+|\\s+$/g,'')\"
+        onfocus=\"javascript:this.value=this.value.replace(/^\\s+|\\s+$/g,'')\" class=\"text\"
+        id=\"description\" />\r\n                </div>\r\n            \r\n\r\n            \r\n
+        \               <div class=\"applicantName\">\r\n                    <label
+        for=\"applicantName\">\r\n                        Applicant Name:\r\n                    </label>\r\n
+        \                   <input type=\"text\" name=\"searchCriteria.applicantName\"
+        maxlength=\"255\" autocomplete=\"off\" value=\"\" onblur=\"javascript:this.value=this.value.replace(/^\\s+|\\s+$/g,'')\"
+        onfocus=\"javascript:this.value=this.value.replace(/^\\s+|\\s+$/g,'')\" class=\"text\"
+        id=\"applicantName\" />\r\n                </div>\r\n            \r\n\r\n
+        \           \r\n                <div class=\"caseType\">\r\n                    <label
+        for=\"caseType\">\r\n                        Application Type:\r\n                    </label>\r\n
+        \                   <select name=\"searchCriteria.caseType\" id=\"caseType\"><option
+        value=\"\">All</option>\r\n                        <option value=\"ADV\">Advertisement</option>\r\n<option
+        value=\"AGD\">Agricultural Determination</option>\r\n<option value=\"DEM\">Application
+        for Demolition</option>\r\n<option value=\"AAD\">Appropriate Alternative Development</option>\r\n<option
+        value=\"CLD\">Certificate of Lawful Dev - proposed</option>\r\n<option value=\"CLU\">Certificate
+        of Lawful Use - Existing</option>\r\n<option value=\"CAC\">Conservation Area
+        Consent</option>\r\n<option value=\"CMA\">County Matters - Application Transferred</option>\r\n<option
+        value=\"DET\">Determination (T&amp;CP Act 1990 Section 64)</option>\r\n<option
+        value=\"DOC\">Discharge of Condition(s)</option>\r\n<option value=\"ENF\">Enforcement</option>\r\n<option
+        value=\"EIA\">Environmental Impact Assessment</option>\r\n<option value=\"EUC\">Established
+        Use Certificate (Historic)</option>\r\n<option value=\"FMB\">Form B - Overhead/Electricity</option>\r\n<option
+        value=\"FUL\">Full Planning Permission</option>\r\n<option value=\"HSC\">Hazardous
+        Substances Consent</option>\r\n<option value=\"HSE\">Householder Planning
+        Permission</option>\r\n<option value=\"HYB\">Hybrid Application</option>\r\n<option
+        value=\"LBC\">Listed Building Consent</option>\r\n<option value=\"MIN\">Minerals</option>\r\n<option
+        value=\"NMA\">Non Material Amendment</option>\r\n<option value=\"NMH\">Non
+        Material Amendment Householder</option>\r\n<option value=\"OUT\">Outline Planning
+        Permission</option>\r\n<option value=\"OHL\">Overhead Lines (Circular 34/76)</option>\r\n<option
+        value=\"PRAP\">Prior Approval</option>\r\n<option value=\"PAT\">Prior Approval
+        Telecommunications</option>\r\n<option value=\"RG4\">Reg 4 (1976Regs) Dev
+        for sale by Council</option>\r\n<option value=\"RGX\">Regulation 10</option>\r\n<option
+        value=\"REM\">Removal of condition(s)</option>\r\n<option value=\"REN\">Renewal
+        of previous permission</option>\r\n<option value=\"RFO\">Request for observations</option>\r\n<option
+        value=\"RES\">Reserved Matters</option>\r\n<option value=\"SCR\">Screening
+        Opinion</option>\r\n<option value=\"MPO\">Section 106 Modification</option>\r\n<option
+        value=\"S53\">Section 53 (1972 Act)</option>\r\n<option value=\"TAP\">Temporary
+        Permission</option>\r\n<option value=\"VAR\">Variation of conditions</option>\r\n<option
+        value=\"GOV\">Welsh Office Circular 37/84</option></select>\r\n                </div>\r\n
+        \           \r\n\r\n            \r\n\r\n            \r\n\r\n            \r\n\r\n
+        \           \r\n\r\n            \r\n                <div class=\"ward\">\r\n
+        \                   <label for=\"ward\">\r\n                        Ward:\r\n
+        \                   </label>\r\n                    <select name=\"searchCriteria.ward\"
+        id=\"ward\"><option value=\"\">All</option>\r\n                        <option
+        value=\"ADAM\">ADAMSDOWN</option>\r\n<option value=\"BUTE\">BUTETOWN</option>\r\n<option
+        value=\"CAER\">CAERAU</option>\r\n<option value=\"CANT\">CANTON</option>\r\n<option
+        value=\"CATH\">CATHAYS</option>\r\n<option value=\"CRE\">CREIGAU/ST FAGANS</option>\r\n<option
+        value=\"CYNC\">CYNCOED</option>\r\n<option value=\"ELY\">ELY</option>\r\n<option
+        value=\"FAIR\">FAIRWATER</option>\r\n<option value=\"GABA\">GABALFA</option>\r\n<option
+        value=\"GRAN\">GRANGETOWN</option>\r\n<option value=\"HEAT\">HEATH</option>\r\n<option
+        value=\"LISV\">LISVANE</option>\r\n<option value=\"LLDF\">LLANDAFF</option>\r\n<option
+        value=\"LLDN\">LLANDAFF NORTH</option>\r\n<option value=\"LLAN\">LLANISHEN</option>\r\n<option
+        value=\"LLRU\">LLANRUMNEY</option>\r\n<option value=\"PENT\">PENTWYN</option>\r\n<option
+        value=\"PYCH\">PENTYRCH</option>\r\n<option value=\"PENY\">PENYLAN</option>\r\n<option
+        value=\"PLAS\">PLASNEWYDD</option>\r\n<option value=\"PONT/STME\">PONTPRENNAU-OLD
+        ST MELLONS</option>\r\n<option value=\"PON\">PONTPRENNAU/ST MELLONS</option>\r\n<option
+        value=\"RADY\">RADYR</option>\r\n<option value=\"RHIW\">RHIWBINA</option>\r\n<option
+        value=\"RIVE\">RIVERSIDE</option>\r\n<option value=\"RUMN\">RUMNEY</option>\r\n<option
+        value=\"SPLO\">SPLOTT</option>\r\n<option value=\"TON\">TONGWYNLAIS/WHITCHURCH</option>\r\n<option
+        value=\"TROW\">TROWBRIDGE</option>\r\n<option value=\"WHIT/TONG\">WHITCHURCH-TONGWYNLAIS</option>\r\n<option
+        value=\"WHI\">WHITCHURCH/TONGWYNLAIS</option></select>\r\n                </div>\r\n
+        \           \r\n\r\n            \r\n\r\n            \r\n                <div
+        class=\"conservationArea\">\r\n                    <label for=\"conservationArea\">\r\n
+        \                       Conservation Area:\r\n                    </label>\r\n
+        \                   \r\n                            <select name=\"searchCriteria.conservationArea\"
+        id=\"conservationArea\"><option value=\"\">All</option>\r\n                                <option
+        value=\"NULL\"></option>\r\n<option value=\"CA1\">Cardiff Road</option>\r\n<option
+        value=\"CA2\">Cathays Park</option>\r\n<option value=\"CA3\">Cathedral Road</option>\r\n<option
+        value=\"CA4\">Central Area No. 1</option>\r\n<option value=\"CA5\">Central
+        Area No. 2</option>\r\n<option value=\"C18\">Charles Street Conservation Area</option>\r\n<option
+        value=\"CA11\">Church Road</option>\r\n<option value=\"C19\">Churchill Way
+        Conservation Area</option>\r\n<option value=\"CA10\">Conway Road</option>\r\n<option
+        value=\"C21\">Craig-y-Parc, Pentyrch</option>\r\n<option value=\"C22\">Gwaelod-y-Garth</option>\r\n<option
+        value=\"C23\">Insole Court</option>\r\n<option value=\"CA6\">Llandaff</option>\r\n<option
+        value=\"CA7\">Melingriffith</option>\r\n<option value=\"CA8\">Mount Stuart
+        Square</option>\r\n<option value=\"C24\">Oakfield Street</option>\r\n<option
+        value=\"C13\">Pierhead</option>\r\n<option value=\"C20\">Queen Street Conservation
+        Area</option>\r\n<option value=\"CA9\">Rhiwbina Garden Village</option>\r\n<option
+        value=\"C10\">Roath Mill Gardens</option>\r\n<option value=\"C11\">Roath Park</option>\r\n<option
+        value=\"C12\">Roath Park Lake and Gardens</option>\r\n<option value=\"C25\">St
+        Catwg&#39;s, Pentyrch</option>\r\n<option value=\"C14\">St Fagans</option>\r\n<option
+        value=\"C26\">St Mary Street</option>\r\n<option value=\"C15\">St Mellons</option>\r\n<option
+        value=\"C16\">The Parade</option>\r\n<option value=\"XXXX\">To be entered
+        locally</option>\r\n<option value=\"C27\">Windsor Place</option>\r\n<option
+        value=\"C17\">Wordsworth Avenue</option></select>\r\n                    \r\n
+        \                   \r\n                </div>\r\n            \r\n\r\n            \r\n
+        \               <div class=\"agent\">\r\n                    <label for=\"agent\">\r\n
+        \                       Agent:\r\n                    </label>\r\n                    <input
+        type=\"text\" name=\"searchCriteria.agent\" maxlength=\"255\" autocomplete=\"off\"
+        value=\"\" onblur=\"javascript:this.value=this.value.replace(/^\\s+|\\s+$/g,'')\"
+        onfocus=\"javascript:this.value=this.value.replace(/^\\s+|\\s+$/g,'')\" class=\"text\"
+        id=\"agent\" />\r\n                </div>\r\n            \r\n            <!--
+        TODO TTP:66360 Update upgrade SQL script to use agent instead of agentLicence
+        in the PREFS_SYSTEM_VALUES table -->\r\n            \r\n\r\n            \r\n
+        \               <div class=\"caseStatus\">\r\n                    <label for=\"caseStatus\">\r\n
+        \                       Status:\r\n                    </label>\r\n                    <select
+        name=\"searchCriteria.caseStatus\" id=\"caseStatus\"><option value=\"\">All</option>\r\n
+        \                       <option value=\"Awaiting decision\">Awaiting decision</option>\r\n<option
+        value=\"Decided\">Decided</option>\r\n<option value=\"Registered\">Registered</option>\r\n<option
+        value=\"Unknown\">Unknown</option>\r\n<option value=\"Withdrawn\">Withdrawn</option></select>\r\n
+        \               </div>\r\n            \r\n\r\n            \r\n\r\n            \r\n\r\n
+        \           \r\n\r\n            \r\n\r\n            \r\n\r\n            \r\n
+        \               <div class=\"caseDecision\">\r\n                    <label
+        for=\"caseDecision\">\r\n                        Decision:\r\n                    </label>\r\n
+        \                   <select name=\"searchCriteria.caseDecision\" id=\"caseDecision\"><option
+        value=\"\">All</option>\r\n                        <option value=\"APRE\">Application
+        Received</option>\r\n<option value=\"DEV\">Constitutes Devel. (Section 64
+        Determ.)</option>\r\n<option value=\"DPR\">Deemed Permission</option>\r\n<option
+        value=\"DRF\">Deemed Refusal</option>\r\n<option value=\"DWN\">Deemed Withdrawn</option>\r\n<option
+        value=\"FDC\">Full Discharge of Condition</option>\r\n<option value=\"HSC\">Hazardous
+        Substance Consent</option>\r\n<option value=\"NPA\">No Prior Approval required</option>\r\n<option
+        value=\"NDV\">Not development (Section 64 Determ.)</option>\r\n<option value=\"PDC\">Partial
+        Discharge of Condition (s)</option>\r\n<option value=\"GTD\">Permission be
+        granted</option>\r\n<option value=\"PER\">Permission be granted</option>\r\n<option
+        value=\"PERU\">Permission be granted - unique</option>\r\n<option value=\"PNR\">Permission
+        not required</option>\r\n<option value=\"PRQ\">Permission Required</option>\r\n<option
+        value=\"PERP\">Permitted DIOC</option>\r\n<option value=\"REF\">Planning Permission
+        be refused</option>\r\n<option value=\"PAG\">Prior Approval be granted</option>\r\n<option
+        value=\"PAR\">Prior Approval be refused</option>\r\n<option value=\"PAN\">Prior
+        Approval Notification</option>\r\n<option value=\"RNO\">Raise No Objection</option>\r\n<option
+        value=\"ROB\">Raise Objections</option>\r\n<option value=\"RTD\">Refuse to
+        Discharge</option>\r\n<option value=\"RPA\">Requires Prior Approval</option>\r\n<option
+        value=\"RTG\">Resolved to Grant</option>\r\n<option value=\"RS\">Response
+        Sent</option>\r\n<option value=\"AGM\">Section 106 (Report back to Committee)</option>\r\n<option
+        value=\"106\">Section 106 Agreement</option>\r\n<option value=\"SPL\">Split
+        decision (part app./part ref.)</option>\r\n<option value=\"TTC\">Transferred
+        to County Council</option>\r\n<option value=\"TTA\">Transferred to Welsh Assembly
+        Government</option>\r\n<option value=\"WTD\">Withdrawn - Appeal against non-determine</option>\r\n<option
+        value=\"WDN\">Withdrawn by Applicant</option>\r\n<option value=\"WCI\">Withdrawn
+        Called In : Secretary of State</option></select>\r\n                </div>\r\n
+        \           \r\n\r\n            \r\n                <div class=\"appealStatus\">\r\n
+        \                   <label for=\"appealStatus\">\r\n                        Appeal
+        Status:\r\n                    </label>\r\n                    <select name=\"searchCriteria.appealStatus\"
+        id=\"appealStatus\"><option value=\"\">All</option>\r\n                        <option
+        value=\"Appeal decided\">Appeal decided</option>\r\n<option value=\"Appeal
+        lodged\">Appeal lodged</option>\r\n<option value=\"Unknown\">Unknown</option>\r\n<option
+        value=\"Withdrawn\">Withdrawn</option></select>\r\n                </div>\r\n
+        \           \r\n\r\n            \r\n                <div class=\"appealDecision\">\r\n
+        \                   <label for=\"appealDecision\">\r\n                        Appeal
+        Decision:\r\n                    </label>\r\n                    <select name=\"searchCriteria.appealDecision\"
+        id=\"appealDecision\"><option value=\"\">All</option>\r\n                        <option
+        value=\"ALW\">Allow</option>\r\n<option value=\"INQ\">Appeal Disallowed -
+        Subject of Inquiry</option>\r\n<option value=\"DIS\">Dismiss</option>\r\n<option
+        value=\"INQA\">Inquiry Allowed</option>\r\n<option value=\"INQD\">Inquiry
+        Disallowed</option>\r\n<option value=\"ZZZ\">No further action on appeal</option>\r\n<option
+        value=\"PAL\">Part allow</option>\r\n<option value=\"WWN\">Withdrawn</option></select>\r\n
+        \               </div>\r\n            \r\n\r\n            \r\n\r\n            \r\n\r\n
+        \           \r\n                <div class=\"developmentType\">\r\n                    <label
+        for=\"developmentType\">\r\n                        Development Type:\r\n
+        \                   </label>\r\n                    <select name=\"searchCriteria.developmentType\"
+        id=\"developmentType\"><option value=\"\">All</option>\r\n                        <option
+        value=\"CADV\">Advertisements</option>\r\n<option value=\"B1\">Business (B1)</option>\r\n<option
+        value=\"CAC\">Conservation Area Consent</option>\r\n<option value=\"DIOC\">Discharge
+        of Conditions</option>\r\n<option value=\"B2\">General Industry (B2)</option>\r\n<option
+        value=\"CGEN\">General Regulations</option>\r\n<option value=\"CHSE\">Householder</option>\r\n<option
+        value=\"LN\">Licensing Notification</option>\r\n<option value=\"LBC\">Listed
+        Buildings</option>\r\n<option value=\"MAJD\">Major - Dwellings (C3)</option>\r\n<option
+        value=\"MISW\">Major - Industry/Storage/Distribution</option>\r\n<option value=\"MOPA\">Major
+        - Other Principal Uses</option>\r\n<option value=\"MAJR\">Major - Retail (A1-A3)</option>\r\n<option
+        value=\"MAJO\">Major Offices (B1(a))</option>\r\n<option value=\"CMIN\">Minerals</option>\r\n<option
+        value=\"MIND\">Minor - Dwellings (C3)</option>\r\n<option value=\"MHSW\">Minor
+        - Industry/Storage/Distribution</option>\r\n<option value=\"MINO\">Minor -
+        Offices (B1(a))</option>\r\n<option value=\"MIPA\">Minor - Other Principal
+        Uses</option>\r\n<option value=\"MINR\">Minor - Retail (A1-A3)</option>\r\n<option
+        value=\"Misc\">Miscellaneous</option>\r\n<option value=\"BMul\">Multiple Uses
+        (B1/B2/B8)</option>\r\n<option value=\"NMA\">Non Material Amendment</option>\r\n<option
+        value=\"NMH\">Non Material Householder</option>\r\n<option value=\"OTH\">Other
+        Consent Types</option>\r\n<option value=\"PDV\">Permitted Development</option>\r\n<option
+        value=\"PAMJ\">Pre App - Major</option>\r\n<option value=\"PAMN\">Pre App
+        - Minor</option>\r\n<option value=\"PAHS\">Pre App Householder</option>\r\n<option
+        value=\"PAST\">Pre App Strategic Site</option>\r\n<option value=\"REVA\">Renewals
+        and Variation of Conditions</option>\r\n<option value=\"B8\">Storage and Distribution
+        (B8)</option>\r\n<option value=\"MAWD\">Waste Disposal</option></select>\r\n
+        \               </div>\r\n            \r\n\r\n            \r\n                <div
+        class=\"address\">\r\n                    <label for=\"address\">\r\n                        Address:\r\n
+        \                   </label>\r\n\r\n                    \r\n                        \r\n
+        \                       <input type=\"hidden\" name=\"caseAddressType\" value=\"Application\"
+        />\r\n                    \r\n                    \r\n\r\n                        \r\n\r\n
+        \                       \r\n                        <span class=\"fieldhelp\">\r\n
+        \                           <a href=\"/online-applications-skin/help/fieldhelp/addressNoPostcode.htm\"
+        target=\"_blank\" rel=\"external\" title=\"Help with Address (opens in a new
+        window)\">\r\n                                <img src=\"/online-applications-skin/images/help.gif\"
+        alt=\"Help icon\" width=\"16\" height=\"16\" class=\"helpicon\"/>\r\n                            </a>\r\n
+        \                       </span>\r\n                        \r\n                    \r\n
+        \                   <input type=\"text\" name=\"searchCriteria.address\" maxlength=\"255\"
+        autocomplete=\"off\" value=\"\" onblur=\"javascript:this.value=this.value.replace(/^\\s+|\\s+$/g,'')\"
+        onfocus=\"javascript:this.value=this.value.replace(/^\\s+|\\s+$/g,'')\" class=\"text\"
+        id=\"address\" />\r\n\r\n                </div>\r\n            \r\n        </fieldset>\r\n
+        \   </div>\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n    <h3>\r\n        Dates\r\n
+        \   </h3>\n\r\n    <div id=\"dates\">\r\n\t\t\r\n        <p class=\"help\">\r\n
+        \           Enter a date range (a start date and an end date) for the criteria
+        that you are interested in. The date fields may be entered manually using
+        the date format dd/mm/yyyy (e.g. 21/06/2008). Alternatively, click on the
+        calendar button and pick a date.\r\n        </p>\r\n\t\t\r\n        <fieldset>\r\n
+        \           <legend>\r\n                Dates\r\n            </legend>\r\n\r\n
+        \           \r\n            \r\n                \n<div class=\"row\">\n<div
+        class=\"col-dateFrom\">\n   <label for=\"applicationReceivedStart\">\n       Date
+        Received:<span class=\"hide\"> (from)</span>\n       \n   </label>\n   <input
+        type=\"text\" name=\"date(applicationReceivedStart)\" value=\"\" class=\"date\"
+        id=\"applicationReceivedStart\" />\n   <a href=\"#\" onclick=\"calendar.select(document.forms['searchCriteriaForm'].applicationReceivedStart,'applicationReceivedStart_button','dd/MM/yyyy');
+        return false;\" name=\"applicationReceivedStart_button\" id=\"applicationReceivedStart_button\">\n
+        \      <img src=\"/online-applications-skin/images/datepicker.gif\" alt=\"Date
+        Received (from) calendar\" title=\"Date Received (from) calendar\" width=\"16\"
+        height=\"12\"/>\n   </a>\n</div><div class=\"col-dateTo\">\n   <label class=\"innerlabel\"
+        for=\"applicationReceivedEnd\">\n       <span class=\"hide\">Date Received:
+        (</span>to:<span class=\"hide\">)</span>\n       \n   </label>\n   <input
+        type=\"text\" name=\"date(applicationReceivedEnd)\" value=\"\" class=\"date\"
+        id=\"applicationReceivedEnd\" />\n   <a href=\"#\" onclick=\"calendar.select(document.forms['searchCriteriaForm'].applicationReceivedEnd,'applicationReceivedEnd_button','dd/MM/yyyy');
+        return false;\" name=\"applicationReceivedEnd_button\" id=\"applicationReceivedEnd_button\">\n
+        \      <img src=\"/online-applications-skin/images/datepicker.gif\" alt=\"Date
+        Received (to) calendar\" title=\"Date Received (to) calendar\" width=\"16\"
+        height=\"12\"/>\n   </a>\n</div></div>\n\r\n            \r\n            \r\n
+        \               \n<div class=\"row\">\n<div class=\"col-dateFrom\">\n   <label
+        for=\"applicationValidatedStart\">\n       Date Validated:<span class=\"hide\">
+        (from)</span>\n       \n   </label>\n   <input type=\"text\" name=\"date(applicationValidatedStart)\"
+        value=\"\" class=\"date\" id=\"applicationValidatedStart\" />\n   <a href=\"#\"
+        onclick=\"calendar.select(document.forms['searchCriteriaForm'].applicationValidatedStart,'applicationValidatedStart_button','dd/MM/yyyy');
+        return false;\" name=\"applicationValidatedStart_button\" id=\"applicationValidatedStart_button\">\n
+        \      <img src=\"/online-applications-skin/images/datepicker.gif\" alt=\"Date
+        Validated (from) calendar\" title=\"Date Validated (from) calendar\" width=\"16\"
+        height=\"12\"/>\n   </a>\n</div><div class=\"col-dateTo\">\n   <label class=\"innerlabel\"
+        for=\"applicationValidatedEnd\">\n       <span class=\"hide\">Date Validated:
+        (</span>to:<span class=\"hide\">)</span>\n       \n   </label>\n   <input
+        type=\"text\" name=\"date(applicationValidatedEnd)\" value=\"\" class=\"date\"
+        id=\"applicationValidatedEnd\" />\n   <a href=\"#\" onclick=\"calendar.select(document.forms['searchCriteriaForm'].applicationValidatedEnd,'applicationValidatedEnd_button','dd/MM/yyyy');
+        return false;\" name=\"applicationValidatedEnd_button\" id=\"applicationValidatedEnd_button\">\n
+        \      <img src=\"/online-applications-skin/images/datepicker.gif\" alt=\"Date
+        Validated (to) calendar\" title=\"Date Validated (to) calendar\" width=\"16\"
+        height=\"12\"/>\n   </a>\n</div></div>\n\r\n            \r\n            \r\n
+        \               \n<div class=\"row\">\n<div class=\"col-dateFrom\">\n   <label
+        for=\"applicationCommitteeStart\">\n       Date Actual Committee:<span class=\"hide\">
+        (from)</span>\n       \n   </label>\n   <input type=\"text\" name=\"date(applicationCommitteeStart)\"
+        value=\"\" class=\"date\" id=\"applicationCommitteeStart\" />\n   <a href=\"#\"
+        onclick=\"calendar.select(document.forms['searchCriteriaForm'].applicationCommitteeStart,'applicationCommitteeStart_button','dd/MM/yyyy');
+        return false;\" name=\"applicationCommitteeStart_button\" id=\"applicationCommitteeStart_button\">\n
+        \      <img src=\"/online-applications-skin/images/datepicker.gif\" alt=\"Date
+        Actual Committee (from) calendar\" title=\"Date Actual Committee (from) calendar\"
+        width=\"16\" height=\"12\"/>\n   </a>\n</div><div class=\"col-dateTo\">\n
+        \  <label class=\"innerlabel\" for=\"applicationCommitteeEnd\">\n       <span
+        class=\"hide\">Date Actual Committee: (</span>to:<span class=\"hide\">)</span>\n
+        \      \n   </label>\n   <input type=\"text\" name=\"date(applicationCommitteeEnd)\"
+        value=\"\" class=\"date\" id=\"applicationCommitteeEnd\" />\n   <a href=\"#\"
+        onclick=\"calendar.select(document.forms['searchCriteriaForm'].applicationCommitteeEnd,'applicationCommitteeEnd_button','dd/MM/yyyy');
+        return false;\" name=\"applicationCommitteeEnd_button\" id=\"applicationCommitteeEnd_button\">\n
+        \      <img src=\"/online-applications-skin/images/datepicker.gif\" alt=\"Date
+        Actual Committee (to) calendar\" title=\"Date Actual Committee (to) calendar\"
+        width=\"16\" height=\"12\"/>\n   </a>\n</div></div>\n\r\n            \r\n
+        \           \r\n                \n<div class=\"row\">\n<div class=\"col-dateFrom\">\n
+        \  <label for=\"applicationDecisionStart\">\n       Decision Date:<span class=\"hide\">
+        (from)</span>\n       \n   </label>\n   <input type=\"text\" name=\"date(applicationDecisionStart)\"
+        value=\"\" class=\"date\" id=\"applicationDecisionStart\" />\n   <a href=\"#\"
+        onclick=\"calendar.select(document.forms['searchCriteriaForm'].applicationDecisionStart,'applicationDecisionStart_button','dd/MM/yyyy');
+        return false;\" name=\"applicationDecisionStart_button\" id=\"applicationDecisionStart_button\">\n
+        \      <img src=\"/online-applications-skin/images/datepicker.gif\" alt=\"Decision
+        Date (from) calendar\" title=\"Decision Date (from) calendar\" width=\"16\"
+        height=\"12\"/>\n   </a>\n</div><div class=\"col-dateTo\">\n   <label class=\"innerlabel\"
+        for=\"applicationDecisionEnd\">\n       <span class=\"hide\">Decision Date:
+        (</span>to:<span class=\"hide\">)</span>\n       \n   </label>\n   <input
+        type=\"text\" name=\"date(applicationDecisionEnd)\" value=\"\" class=\"date\"
+        id=\"applicationDecisionEnd\" />\n   <a href=\"#\" onclick=\"calendar.select(document.forms['searchCriteriaForm'].applicationDecisionEnd,'applicationDecisionEnd_button','dd/MM/yyyy');
+        return false;\" name=\"applicationDecisionEnd_button\" id=\"applicationDecisionEnd_button\">\n
+        \      <img src=\"/online-applications-skin/images/datepicker.gif\" alt=\"Decision
+        Date (to) calendar\" title=\"Decision Date (to) calendar\" width=\"16\" height=\"12\"/>\n
+        \  </a>\n</div></div>\n\r\n            \r\n            \r\n                \n<div
+        class=\"row\">\n<div class=\"col-dateFrom\">\n   <label for=\"appealDecisionStart\">\n
+        \      Appeal Decision Date:<span class=\"hide\"> (from)</span>\n       \n
+        \  </label>\n   <input type=\"text\" name=\"date(appealDecisionStart)\" value=\"\"
+        class=\"date\" id=\"appealDecisionStart\" />\n   <a href=\"#\" onclick=\"calendar.select(document.forms['searchCriteriaForm'].appealDecisionStart,'appealDecisionStart_button','dd/MM/yyyy');
+        return false;\" name=\"appealDecisionStart_button\" id=\"appealDecisionStart_button\">\n
+        \      <img src=\"/online-applications-skin/images/datepicker.gif\" alt=\"Appeal
+        Decision Date (from) calendar\" title=\"Appeal Decision Date (from) calendar\"
+        width=\"16\" height=\"12\"/>\n   </a>\n</div><div class=\"col-dateTo\">\n
+        \  <label class=\"innerlabel\" for=\"appealDecisionEnd\">\n       <span class=\"hide\">Appeal
+        Decision Date: (</span>to:<span class=\"hide\">)</span>\n       \n   </label>\n
+        \  <input type=\"text\" name=\"date(appealDecisionEnd)\" value=\"\" class=\"date\"
+        id=\"appealDecisionEnd\" />\n   <a href=\"#\" onclick=\"calendar.select(document.forms['searchCriteriaForm'].appealDecisionEnd,'appealDecisionEnd_button','dd/MM/yyyy');
+        return false;\" name=\"appealDecisionEnd_button\" id=\"appealDecisionEnd_button\">\n
+        \      <img src=\"/online-applications-skin/images/datepicker.gif\" alt=\"Appeal
+        Decision Date (to) calendar\" title=\"Appeal Decision Date (to) calendar\"
+        width=\"16\" height=\"12\"/>\n   </a>\n</div></div>\n\r\n            \r\n\r\n
+        \           \r\n            \r\n            \r\n            \r\n            \r\n\r\n
+        \           \r\n            \r\n\r\n            \r\n            \r\n            \r\n
+        \           \r\n\r\n            \r\n            \r\n\r\n            \r\n            \r\n
+        \           \r\n            \r\n            \r\n\r\n        </fieldset>\r\n
+        \   </div>\r\n\r\n\r\n    <div class=\"buttons\">\r\n\r\n        \r\n        <input
+        type=\"hidden\" name=\"searchType\" value=\"Application\" />\r\n\r\n        <input
+        type=\"submit\" value=\"Search\" class=\"button primary\" />\r\n        <input
+        type=\"submit\" name=\"org.apache.struts.taglib.html.CANCEL\" value=\"Reset\"
+        class=\"button\" onclick=\"bCancel=true;\" />\r\n    </div>\r\n    \r\n    </form>\r\n</div>\r\n<!--
+        #EndEditable -->\r\n                    <!-- #BeginEditable \"pagefoot\" --><!--
+        #EndEditable -->\r\n                </div>\r\n                <!-- END WAM
+        CONTENT -->\r\n                \r\n                <p id=\"poweredBy\"><a
+        href=\"http://www.idoxgroup.com/\" target=\"_blank\" title=\"This link will
+        open a new window\"><img src=\"/online-applications-skin/images/idox.gif\"
+        alt=\"an Idox solution\" /></a></p>\r\n            </div>\t\r\n\t\t\t<div
+        id=\"footer\">\r\n\t\t\t\t<div class=\"container\">\t\t\t\t\t\r\n\t\t\t\t\t<div
+        id=\"links\">\r\n\t\t\t\t\t\t<ul>\r\n\t\t\t\t\t\t\t<li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Site_Map/Pages/default.aspx\">Site
+        map</a></li><li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Cookies/Pages/Cookies.aspx\">Cookies</a></li><li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/New_Disclaimer/Pages/default.aspx\">Disclaimer</a></li>\r\n\t\t\t\t\t\t</ul>\r\n\t\t\t\t\t</div>\r\n\t\t\t\t\t<div
+        class=\"clear\"></div>\r\n\t\t\t\t</div>\r\n\t\t\t</div>\r\n\t\t\t<div id=\"footerBottom\">\r\n\t\t\t
+        \   <div class=\"container\">\r\n\t\t\t        <div id=\"footercontent\"><p>&copy;
+        <script type=\"text/javascript\">document.write(new Date().getFullYear());</script>
+        Cardiff Council</p></div>\r\n\t\t\t        <div class=\"clear\"></div>\r\n\t\t\t
+        \   </div>\r\n\t\t\t</div>\r\n        </div>    \r\n    </div>  \r\n    <!--
+        IDOX PA END -->           \r\n\t\r\n</body>\r\n</html>\r\n\r\n"
+    http_version: 
+  recorded_at: Mon, 15 Apr 2019 11:13:33 GMT
+- request:
+    method: post
+    uri: https://planningonline.cardiff.gov.uk/online-applications/advancedSearchResults.do?action=firstPage
+    body:
+      encoding: UTF-8
+      string: searchCriteria.reference=&searchCriteria.planningPortalReference=&searchCriteria.alternativeReference=&searchCriteria.description=&searchCriteria.applicantName=&searchCriteria.caseType=&searchCriteria.ward=&searchCriteria.conservationArea=&searchCriteria.agent=&searchCriteria.caseStatus=&searchCriteria.caseDecision=&searchCriteria.appealStatus=&searchCriteria.appealDecision=&searchCriteria.developmentType=&caseAddressType=Application&searchCriteria.address=&date%28applicationReceivedStart%29=&date%28applicationReceivedEnd%29=&date%28applicationValidatedStart%29=&date%28applicationValidatedEnd%29=&date%28applicationCommitteeStart%29=&date%28applicationCommitteeEnd%29=&date%28applicationDecisionStart%29=08%2F04%2F2019&date%28applicationDecisionEnd%29=09%2F04%2F2019&date%28appealDecisionStart%29=&date%28appealDecisionEnd%29=&searchType=Application
+    headers:
+      Accept-Encoding:
+      - gzip,deflate,identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mechanize/2.7.6 Ruby/2.6.2p47 (http://github.com/sparklemotion/mechanize/)
+      Accept-Charset:
+      - ISO-8859-1,utf-8;q=0.7,*;q=0.7
+      Accept-Language:
+      - en-us,en;q=0.5
+      Cookie:
+      - JSESSIONID=ss9pKoHL32yHmhJQONSykek96zXCSSZ75skxJ5v1.vmidoxweblve; WSLang-CFC001=en
+      Host:
+      - planningonline.cardiff.gov.uk
+      Referer:
+      - https://planningonline.cardiff.gov.uk/online-applications/search.do?action=advanced
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '856'
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '300'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - text/html; charset=UTF-8
+      Expires:
+      - Mon, 15 Apr 2019 11:14:07 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ua-Compatible:
+      - IE=edge
+      Server:
+      - Apache
+      Set-Cookie:
+      - WSLang-CFC001=EN; expires=Mon, 15-Apr-2069 11:14:05 GMT; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 15 Apr 2019 11:14:07 GMT
+      Content-Length:
+      - '25482'
+    body:
+      encoding: UTF-8
+      string: "\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \   \r\n\r\n\r\n\r\n\r\n\r\n<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0
+        Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\r\n<html
+        lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\r\n<head>\r\n\t\r\n\t<!--
+        #BeginEditable \"doctitle\" --><title>Search Results</title><!-- #EndEditable
+        -->\r\n    <!-- #BeginEditable \"metatags\" --><!-- #EndEditable -->\r\n\t\r\n
+        \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
+        />\r\n\t\r\n\t<!-- Customer metatags -->\r\n\t\r\n\t\r\n\t<!-- Favicon link
+        -->\r\n    <link rel=\"icon\" href=\"/online-applications-skin/images/cardiff/favicon.ico\"
+        type=\"image/x-icon\" />\r\n\t\r\n    <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/screen.css\"
+        type=\"text/css\" media=\"screen,projection\" />\r\n    <link rel=\"stylesheet\"
+        href=\"/online-applications-skin/styles/theme1.css\" type=\"text/css\"/>    \r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/print.css\"
+        type=\"text/css\" media=\"print\" />\r\n\t\r\n    <script type=\"text/javascript\"
+        src=\"/online-applications-skin/scripts/jquery.min.js\"></script>\r\n    <script
+        type=\"text/javascript\" src=\"/online-applications-skin/scripts/jquery.toolbar.idox.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/common.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/checkbox.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/amplify.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/createCommentCookie.js\"></script>\r\n
+        \       \r\n\t<!-- Customer Analytics Script -->\r\n\t\r\n\t\r\n    <script
+        type=\"text/javascript\">\r\n    \t$('html').addClass('js');\r\n    \t$(document).ready(function(){\r\n
+        \   \t\t$('.main#apply>span:first-child').attr('tabindex', '0')\r\n    \t});\r\n
+        \   </script>\r\n    \r\n    <!-- #BeginEditable \"mobile\" --><!-- #EndEditable
+        -->\r\n    <!-- #BeginEditable \"head\" --><!-- #EndEditable -->\r\n    <!--
+        #BeginEditable \"webapp\" --><!-- #EndEditable -->\r\n\r\n</head>\r\n<body>\r\n\r\n
+        \   <a href=\"#pageheading\" class=\"sr-only\">Skip to main content</a>\r\n\r\n
+        \   <!-- IDOX PA START -->\r\n    <div id=\"idox\">\r\n        <div id=\"pa\">\r\n\t\t\t<div
+        id=\"header\"><!-- Selector: Selector 1 -->\r\n<style>\r\n#langStyle{float:right;
+        margin-top: 10px; margin-right: 30px; background:transparent; font-size:13px;
+        cursor:pointer; border:1px solid #fff !important;border-radius:2px; z-index:999;
+        background-color: #fff; padding:2px;}\r\n#langStyle:hover{text-decoration:
+        underline;}</style>\r\n<div>\r\n\r\n<!--CYS--><a id=\"langStyle\" href=\"/online-applications/advancedSearchResults.do?action=firstPage&lang=CY\">Cymraeg</a><!--CYE-->\r\n</div>\r\n\t\t\t\t<div
+        class=\"container\">\r\n\t\t\t\t\t<div id=\"logo\"><a href=\"https://www.cardiff.gov.uk/\"
+        title=\"Cardiff Council home page\"><img src=\"/online-applications-skin/images/cardiff/logo.png\"
+        alt=\"Council logo\" /><span class=\"sr-only\">Cardiff Council</span></a></div>\r\n\t\t\t\t\t<div
+        id=\"headertitle\"><span></span></div>\r\n\t\t\t\t\t<div class=\"clear\"></div>\r\n\t\t\t\t</div>\t\r\n\t\t\t</div>\r\n\t\t\t<div
+        id=\"breadcrumbs\" class=\"container\">\r\n\t\t\t\t<ul>\r\n\t\t\t\t\t\r\n\t\t\t\t</ul>\r\n\t\t\t</div>\r\n
+        \           <div class=\"container\">\r\n       \t\t\t<div id=\"toolbar\"
+        class=\"nojs\">\r\n                    <ul>\t\r\n                        <li
+        id=\"search\" class=\"main\"><span tabindex=\"0\">Search&nbsp;</span><span
+        class=\"caret\"></span>\r\n   \t\t\t\t\t\t\t<ul>\t\r\n\t\t\t\t\t\t\t\t<!--
+        #BeginLibraryItem \"/Library/searchModulesNavItems.lbi\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \       \r\n            <li id=\"planLinks\">\r\n                <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\"
+        >\r\n                    <span>Planning</span>\r\n                </a>\r\n
+        \               <ul>\r\n                    <li id=\"planBasicSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\">\r\n
+        \                           Simple Search\r\n                        </a>\r\n
+        \                   </li>\r\n\r\n                    <li id=\"planAdvancedSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=advanced&amp;searchType=Application\">\r\n
+        \                           Advanced\r\n                        </a>\r\n                    </li>\r\n
+        \                   <li id=\"planListSearch\">\r\n                        <a
+        href=\"/online-applications/search.do?action=weeklyList&amp;searchType=Application\">\r\n
+        \                           Weekly/Monthly Lists\r\n                        </a>\r\n
+        \                   </li>\r\n                    <li id=\"planPropertySearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=property&amp;type=custom\">\r\n
+        \                           Property Search\r\n                        </a>\r\n
+        \                   </li>\r\n\t\t\t\t\t\r\n                    \r\n\t\t\t\t\t\r\n
+        \               </ul>\r\n            </li>\r\n        \r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        <!-- #EndLibraryItem -->\r\n                        \t</ul>\r\n\t\t\t\t\t\t</li>\r\n
+        \                       <!-- #BeginEditable \"applicationForms\" -->\n\n\n\n\n\n
+        \  \n<!-- #EndEditable -->   \t\t\t\t\r\n                        <li id=\"myprofile\"
+        class=\"main\"><span tabindex=\"0\">My Profile&nbsp;</span><span class=\"caret\"></span>\r\n
+        \                           <ul>\r\n                              <!-- #BeginLibraryItem
+        \"/Library/consulteeInTrayNavItem.lbi\" -->\n\n\n\n\n\n\n    <!-- #EndLibraryItem
+        -->\r\n                                <li><a href=\"/online-applications/registered/displayUserDetails.do\">Profile
+        Details</a></li>\r\n                                <li><a href=\"/online-applications/registered/savedSearch.do?action=display\">Saved
+        Searches</a></li>\r\n                                <li><a href=\"/online-applications/registered/userAdmin.do?action=showNotifiedApplications\">Notified
+        Applications</a></li>\r\n                                <li><a href=\"/online-applications/registered/trackedApplication.do?action=display\">Tracked
+        Applications</a></li>\r\n                                <!-- #BeginEditable
+        \"formSubmissions\" -->\n\n\n\n\n\n\n\n\n<!-- #EndEditable -->    \t\r\n                            </ul>\r\n
+        \                       </li>\r\n                        <li id=\"loginLink\"
+        class=\"main\"><!-- #BeginEditable \"loginlogout\" -->\n\n\n\n\n\n\n\n\n\n\n\t<a
+        href=\"/online-applications/registered/userAdmin.do\">Login</a>\n<!-- #EndEditable
+        --></li>\r\n                        <!-- #BeginEditable \"register\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \  \r\n\r\n\r\n\t<li id=\"register\">\r\n        <a href=\"/online-applications/registrationWizard.do?action=start\">Register</a>\r\n\t</li>\r\n\r\n<!--
+        #EndEditable -->\r\n                        <!-- #BeginLibraryItem \"/Library/applyOnlineNavItems.lbi\"
+        -->\r\n\r\n\r\n\r\n\r\n\r\n<!-- #EndLibraryItem -->\r\n                    </ul>\r\n
+        \   \t\t\t</div>\r\n\r\n    \t\t\t<!-- #BeginEditable \"headlinenews\" --><!--
+        #EndEditable -->\r\n                 \r\n                <div id=\"pageheading\">\r\n
+        \                   <h1><strong>Planning</strong>&nbsp;&ndash;&nbsp;<!-- #BeginEditable
+        \"pageheading\" -->\r\n    \n\n\n\n\n\n\n\n\n\nResults for Application Search\n\n\n\n\r\n<!--
+        #EndEditable --></h1>\r\n                    <!-- #BeginEditable \"helplink\"
+        --><!-- #EndEditable -->\r\n                </div>\r\n                \r\n
+        \               <!-- START WAM CONTENT -->\r\n                <div class=\"content\">\r\n
+        \                   <!-- #BeginEditable \"errormsg\" --><!-- #EndEditable
+        -->\r\n                    <!-- #BeginEditable \"pagehead\" --><!-- #EndEditable
+        -->\r\n                    <!-- #BeginEditable \"tabs\" --><!-- #EndEditable
+        -->\r\n                    <!-- #BeginEditable \"tabsubnav\" --><!-- #EndEditable
+        -->\r\n                    <!-- #BeginEditable \"pagebody\" -->\r\n\r\n    \r\n
+        \   \r\n\r\n\r\n    <div id=\"searchtools\">\r\n\t<ul>\r\n\r\n        \r\n
+        \       \r\n            <li>\r\n                <a href=\"/online-applications/refineSearch.do?action=refine\"
+        id=\"refinesearch\"><img src=\"/online-applications-skin/images/button_refinesearch.gif\"
+        alt=\"Refine search icon\" /></a>\r\n            </li>\r\n            \r\n
+        \           \r\n                <li>\r\n                    <a href=\"/online-applications/registered/saveSearch.do?action=saveDialog\"
+        id=\"savesearch\"><img src=\"/online-applications-skin/images/button_savesearch.gif\"
+        alt=\"Save search icon\" /></a>\r\n                </li>\r\n            \r\n
+        \       \r\n\r\n          \r\n            \r\n                <li>\r\n                    <a
+        href=\"/online-applications/pagedSearchResults.do?action=printPreview\" rel=\"external\"
+        id=\"print\" title=\"View a printable version of these search results (opens
+        in a new window)\">\r\n                        <img src=\"/online-applications-skin/images/button_print.gif\"
+        alt=\"Print icon\"/>\r\n                    </a>\r\n                </li>\r\n
+        \           \r\n\t\t</ul>\r\n    </div>\r\n\r\n\r\n\r\n    \r\n        <div
+        id=\"searchfilters\">\r\n\r\n            <form name=\"searchCriteriaForm\"
+        method=\"post\" action=\"/online-applications/pagedSearchResults.do\" id=\"searchResults\">\r\n
+        \               <input type=\"hidden\" name=\"searchCriteria.page\" value=\"1\"
+        />\r\n                <input type=\"hidden\" name=\"action\" value=\"page\"
+        />\r\n\r\n                \r\n                    <span class=\"orderByContainer\">\r\n
+        \                       <label for=\"orderBy\">\r\n                            Sort
+        by\r\n                        </label>\r\n                        <select
+        name=\"orderBy\" id=\"orderBy\"><option value=\"Reference\">Ref. No.</option>\r\n
+        \                           \r\n                                <option value=\"DateReceived\"
+        selected=\"selected\">Date Received</option>\r\n                            \r\n
+        \                               <option value=\"Proposal\">Description</option>\r\n
+        \                           \r\n                                <option value=\"ExpiryDate\">Expiry
+        Date</option></select>\r\n                    </span>\r\n                \r\n\r\n\t\t\t\t<span
+        class=\"orderByDirectionContainer\">\r\n                    <label for=\"orderByDirection\">\r\n
+        \                       Direction\r\n                    </label>\r\n                    <select
+        name=\"orderByDirection\" id=\"orderByDirection\"><option value=\"Ascending\">Ascending</option>\r\n
+        \                       \r\n                            <option value=\"Descending\"
+        selected=\"selected\">Descending</option></select>\r\n\t\t\t\t</span>\r\n\r\n\t\t\t\t<span
+        class=\"resultsPerPage\">\r\n                    <label for=\"resultsPerPage\">\r\n
+        \                       Results per page\r\n                    </label>\r\n
+        \                   <select name=\"searchCriteria.resultsPerPage\" id=\"resultsPerPage\"><option
+        value=\"5\">5</option>\r\n<option value=\"10\" selected=\"selected\">10</option>\r\n<option
+        value=\"20\">20</option>\r\n<option value=\"50\">50</option>\r\n<option value=\"100\">100</option></select>\r\n\t\t\t\t</span>\r\n
+        \               <input type=\"submit\" value=\"Go\" class=\"button primary\"
+        />\r\n            </form>\r\n        </div>\r\n    \r\n\r\n\r\n\r\n<div id=\"searchResultsContainer\"
+        class=\"panel\">\r\n\r\n    \r\n    \r\n\r\n            \r\n            \r\n\r\n
+        \           \r\n    \r\n\r\n<div class=\"col-a\">\r\n\r\n<ul id=\"searchresults\">\r\n
+        \   \r\n    \r\n\r\n        <li class=\"searchresult\">\r\n\r\n            <a
+        href=\"/online-applications/applicationDetails.do?keyVal=_CARDIFF_DCAPR_126851&amp;activeTab=summary\">\r\n
+        \               USE AS A (C4) 6 BEDROOM HOUSE IN MULTIPLE OCCUPATION\r\n            </a>\r\n\r\n
+        \           \r\n                <span class=\"canCommentIndicator\">\r\n                    <img
+        src=\"/online-applications-skin/images/ico_comment.gif\" alt=\"Open for comment
+        icon\"/>\r\n                </span>\r\n            \r\n\r\n            \r\n
+        \               \r\n                \r\n                \r\n\r\n                \r\n
+        \                   <p class=\"address\">\r\n                        \r\n
+        \                       \r\n                        47 ELM STREET, ROATH,
+        CARDIFF, CF24 3QS\r\n                    </p>\r\n                \r\n\r\n
+        \               <p class=\"metaInfo\">\r\n                    Ref. No:\r\n
+        \                   19/00552/MNR\r\n                    <span class=\"divider\">|</span>\r\n\r\n\r\n\r\n
+        \                   \r\n                      \r\n                       \r\n
+        \                        \r\n                          \r\n                            \r\n
+        \                             \r\n                                    Received:\r\n
+        \                                   Thu 07 Mar 2019\r\n                                    <span
+        class=\"divider\">|</span>\r\n                              \r\n                            \r\n
+        \                          \r\n                             \r\n                          \r\n
+        \                       \r\n                       \r\n                     \r\n\r\n
+        \                   \r\n                      \r\n                       \r\n
+        \                       Validated:\r\n                        Thu 21 Mar 2019\r\n
+        \                       <span class=\"divider\">|</span>\r\n                       \r\n
+        \                     \r\n                    \r\n\r\n                    \r\n\r\n
+        \                   Status:\r\n                    Withdrawn\r\n\r\n                    \r\n\r\n
+        \                   \r\n\r\n                    \r\n                    \r\n
+        \               </p>\r\n\r\n            \r\n\r\n            \r\n\r\n        </li>\r\n\r\n
+        \   \r\n\r\n        <li class=\"searchresult\">\r\n\r\n            <a href=\"/online-applications/applicationDetails.do?keyVal=_CARDIFF_DCAPR_126784&amp;activeTab=summary\">\r\n
+        \               SINGLE STOREY REAR EXTENSION WITH PITCH ROOF\r\n            </a>\r\n\r\n
+        \           \r\n                <span class=\"canCommentIndicator\">\r\n                    <img
+        src=\"/online-applications-skin/images/ico_comment.gif\" alt=\"Open for comment
+        icon\"/>\r\n                </span>\r\n            \r\n\r\n            \r\n
+        \               \r\n                \r\n                \r\n\r\n                \r\n
+        \                   <p class=\"address\">\r\n                        \r\n
+        \                       \r\n                        81 KYLE CRESCENT, WHITCHURCH,
+        CARDIFF, CF14 1SU\r\n                    </p>\r\n                \r\n\r\n
+        \               <p class=\"metaInfo\">\r\n                    Ref. No:\r\n
+        \                   19/00503/DCH\r\n                    <span class=\"divider\">|</span>\r\n\r\n\r\n\r\n
+        \                   \r\n                      \r\n                       \r\n
+        \                        \r\n                          \r\n                            \r\n
+        \                             \r\n                                    Received:\r\n
+        \                                   Tue 05 Mar 2019\r\n                                    <span
+        class=\"divider\">|</span>\r\n                              \r\n                            \r\n
+        \                          \r\n                             \r\n                          \r\n
+        \                       \r\n                       \r\n                     \r\n\r\n
+        \                   \r\n                      \r\n                       \r\n
+        \                       Validated:\r\n                        Thu 07 Mar 2019\r\n
+        \                       <span class=\"divider\">|</span>\r\n                       \r\n
+        \                     \r\n                    \r\n\r\n                    \r\n\r\n
+        \                   Status:\r\n                    Decided\r\n\r\n                    \r\n\r\n
+        \                   \r\n\r\n                    \r\n                    \r\n
+        \               </p>\r\n\r\n            \r\n\r\n            \r\n\r\n        </li>\r\n\r\n
+        \   \r\n\r\n        <li class=\"searchresult\">\r\n\r\n            <a href=\"/online-applications/applicationDetails.do?keyVal=_CARDIFF_DCAPR_126566&amp;activeTab=summary\">\r\n
+        \               HEATING AND COOLING PLANT TO THE ROOF AND REAR COURTYARD\r\n
+        \           </a>\r\n\r\n            \r\n\r\n            \r\n                \r\n
+        \               \r\n                \r\n\r\n                \r\n                    <p
+        class=\"address\">\r\n                        \r\n                        \r\n
+        \                       23 WOMANBY STREET, CITY CENTRE, CARDIFF, CF10 1BR\r\n
+        \                   </p>\r\n                \r\n\r\n                <p class=\"metaInfo\">\r\n
+        \                   Ref. No:\r\n                    19/00309/MJR\r\n                    <span
+        class=\"divider\">|</span>\r\n\r\n\r\n\r\n                    \r\n                      \r\n
+        \                      \r\n                         \r\n                          \r\n
+        \                           \r\n                              \r\n                                    Received:\r\n
+        \                                   Thu 14 Feb 2019\r\n                                    <span
+        class=\"divider\">|</span>\r\n                              \r\n                            \r\n
+        \                          \r\n                             \r\n                          \r\n
+        \                       \r\n                       \r\n                     \r\n\r\n
+        \                   \r\n                      \r\n                       \r\n
+        \                       Validated:\r\n                        Thu 14 Feb 2019\r\n
+        \                       <span class=\"divider\">|</span>\r\n                       \r\n
+        \                     \r\n                    \r\n\r\n                    \r\n\r\n
+        \                   Status:\r\n                    Decided\r\n\r\n                    \r\n\r\n
+        \                   \r\n\r\n                    \r\n                    \r\n
+        \               </p>\r\n\r\n            \r\n\r\n            \r\n\r\n        </li>\r\n\r\n
+        \   \r\n\r\n        <li class=\"searchresult\">\r\n\r\n            <a href=\"/online-applications/applicationDetails.do?keyVal=_CARDIFF_DCAPR_126537&amp;activeTab=summary\">\r\n
+        \               1ST FLOOR REAR AND GROUND FLOOR SIDE EXTENSION\r\n            </a>\r\n\r\n
+        \           \r\n\r\n            \r\n                \r\n                \r\n
+        \               \r\n\r\n                \r\n                    <p class=\"address\">\r\n
+        \                       \r\n                        \r\n                        3
+        RHYD Y PENAU ROAD, CYNCOED, CARDIFF, CF23 6PX\r\n                    </p>\r\n
+        \               \r\n\r\n                <p class=\"metaInfo\">\r\n                    Ref.
+        No:\r\n                    19/00284/DCH\r\n                    <span class=\"divider\">|</span>\r\n\r\n\r\n\r\n
+        \                   \r\n                      \r\n                       \r\n
+        \                        \r\n                          \r\n                            \r\n
+        \                             \r\n                                    Received:\r\n
+        \                                   Tue 12 Feb 2019\r\n                                    <span
+        class=\"divider\">|</span>\r\n                              \r\n                            \r\n
+        \                          \r\n                             \r\n                          \r\n
+        \                       \r\n                       \r\n                     \r\n\r\n
+        \                   \r\n                      \r\n                       \r\n
+        \                       Validated:\r\n                        Thu 21 Feb 2019\r\n
+        \                       <span class=\"divider\">|</span>\r\n                       \r\n
+        \                     \r\n                    \r\n\r\n                    \r\n\r\n
+        \                   Status:\r\n                    Decided\r\n\r\n                    \r\n\r\n
+        \                   \r\n\r\n                    \r\n                    \r\n
+        \               </p>\r\n\r\n            \r\n\r\n            \r\n\r\n        </li>\r\n\r\n
+        \   \r\n\r\n        <li class=\"searchresult\">\r\n\r\n            <a href=\"/online-applications/applicationDetails.do?keyVal=_CARDIFF_DCAPR_126508&amp;activeTab=summary\">\r\n
+        \               VARIATION OF CONDITION 2 (APPROVED PLANS) OF 17/03122/DCH\r\n
+        \           </a>\r\n\r\n            \r\n\r\n            \r\n                \r\n
+        \               \r\n                \r\n\r\n                \r\n                    <p
+        class=\"address\">\r\n                        \r\n                        \r\n
+        \                       MILL FARM HOUSE, MILL FARM, ST MELLONS ROAD, LISVANE,
+        CARDIFF, CF14 0SH\r\n                    </p>\r\n                \r\n\r\n
+        \               <p class=\"metaInfo\">\r\n                    Ref. No:\r\n
+        \                   19/00263/DCH\r\n                    <span class=\"divider\">|</span>\r\n\r\n\r\n\r\n
+        \                   \r\n                      \r\n                       \r\n
+        \                        \r\n                          \r\n                            \r\n
+        \                             \r\n                                    Received:\r\n
+        \                                   Fri 08 Feb 2019\r\n                                    <span
+        class=\"divider\">|</span>\r\n                              \r\n                            \r\n
+        \                          \r\n                             \r\n                          \r\n
+        \                       \r\n                       \r\n                     \r\n\r\n
+        \                   \r\n                      \r\n                       \r\n
+        \                       Validated:\r\n                        Mon 11 Feb 2019\r\n
+        \                       <span class=\"divider\">|</span>\r\n                       \r\n
+        \                     \r\n                    \r\n\r\n                    \r\n\r\n
+        \                   Status:\r\n                    Decided\r\n\r\n                    \r\n\r\n
+        \                   \r\n\r\n                    \r\n                    \r\n
+        \               </p>\r\n\r\n            \r\n\r\n            \r\n\r\n        </li>\r\n\r\n
+        \   \r\n\r\n        <li class=\"searchresult\">\r\n\r\n            <a href=\"/online-applications/applicationDetails.do?keyVal=_CARDIFF_DCAPR_126502&amp;activeTab=summary\">\r\n
+        \               NEW BUILD EXTENSION TO EXISTING POOL HALL TO CREATE SMALL
+        RELAX AREA\r\n            </a>\r\n\r\n            \r\n\r\n            \r\n
+        \               \r\n                \r\n                \r\n\r\n                \r\n
+        \                   <p class=\"address\">\r\n                        \r\n
+        \                       \r\n                        BANNATYNE HEALTH CLUB,
+        PARC TY GLAS, LLANISHEN, CARDIFF, CF14 5DU\r\n                    </p>\r\n
+        \               \r\n\r\n                <p class=\"metaInfo\">\r\n                    Ref.
+        No:\r\n                    19/00257/MNR\r\n                    <span class=\"divider\">|</span>\r\n\r\n\r\n\r\n
+        \                   \r\n                      \r\n                       \r\n
+        \                        \r\n                          \r\n                            \r\n
+        \                             \r\n                                    Received:\r\n
+        \                                   Fri 08 Feb 2019\r\n                                    <span
+        class=\"divider\">|</span>\r\n                              \r\n                            \r\n
+        \                          \r\n                             \r\n                          \r\n
+        \                       \r\n                       \r\n                     \r\n\r\n
+        \                   \r\n                      \r\n                       \r\n
+        \                       Validated:\r\n                        Fri 08 Feb 2019\r\n
+        \                       <span class=\"divider\">|</span>\r\n                       \r\n
+        \                     \r\n                    \r\n\r\n                    \r\n\r\n
+        \                   Status:\r\n                    Decided\r\n\r\n                    \r\n\r\n
+        \                   \r\n\r\n                    \r\n                    \r\n
+        \               </p>\r\n\r\n            \r\n\r\n            \r\n\r\n        </li>\r\n\r\n
+        \   \r\n\r\n        <li class=\"searchresult\">\r\n\r\n            <a href=\"/online-applications/applicationDetails.do?keyVal=_CARDIFF_DCAPR_126451&amp;activeTab=summary\">\r\n
+        \               REMOVE EXISTING DECKING AT REAR AND REPLACE WITH GROUND LEVEL
+        AND RAISED PATIOS\r\n            </a>\r\n\r\n            \r\n\r\n            \r\n
+        \               \r\n                \r\n                \r\n\r\n                \r\n
+        \                   <p class=\"address\">\r\n                        \r\n
+        \                       \r\n                        17 PANTGLAS, PENTYRCH,
+        CARDIFF, CF15 9TH\r\n                    </p>\r\n                \r\n\r\n
+        \               <p class=\"metaInfo\">\r\n                    Ref. No:\r\n
+        \                   19/00214/DCH\r\n                    <span class=\"divider\">|</span>\r\n\r\n\r\n\r\n
+        \                   \r\n                      \r\n                       \r\n
+        \                        \r\n                          \r\n                            \r\n
+        \                             \r\n                                    Received:\r\n
+        \                                   Mon 04 Feb 2019\r\n                                    <span
+        class=\"divider\">|</span>\r\n                              \r\n                            \r\n
+        \                          \r\n                             \r\n                          \r\n
+        \                       \r\n                       \r\n                     \r\n\r\n
+        \                   \r\n                      \r\n                       \r\n
+        \                       Validated:\r\n                        Mon 11 Feb 2019\r\n
+        \                       <span class=\"divider\">|</span>\r\n                       \r\n
+        \                     \r\n                    \r\n\r\n                    \r\n\r\n
+        \                   Status:\r\n                    Decided\r\n\r\n                    \r\n\r\n
+        \                   \r\n\r\n                    \r\n                    \r\n
+        \               </p>\r\n\r\n            \r\n\r\n            \r\n\r\n        </li>\r\n\r\n
+        \   \r\n</ul>\r\n\r\n\r\n</div>\r\n\r\n\r\n\r\n\r\n\r\n<div class=\"clear\"></div>\r\n\r\n\r\n\r\n<div
+        class=\"clear\"></div>\r\n</div>\r\n\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"pagefoot\" --><!-- #EndEditable -->\r\n                </div>\r\n
+        \               <!-- END WAM CONTENT -->\r\n                \r\n                <p
+        id=\"poweredBy\"><a href=\"http://www.idoxgroup.com/\" target=\"_blank\" title=\"This
+        link will open a new window\"><img src=\"/online-applications-skin/images/idox.gif\"
+        alt=\"an Idox solution\" /></a></p>\r\n            </div>\t\r\n\t\t\t<div
+        id=\"footer\">\r\n\t\t\t\t<div class=\"container\">\t\t\t\t\t\r\n\t\t\t\t\t<div
+        id=\"links\">\r\n\t\t\t\t\t\t<ul>\r\n\t\t\t\t\t\t\t<li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Site_Map/Pages/default.aspx\">Site
+        map</a></li><li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Cookies/Pages/Cookies.aspx\">Cookies</a></li><li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/New_Disclaimer/Pages/default.aspx\">Disclaimer</a></li>\r\n\t\t\t\t\t\t</ul>\r\n\t\t\t\t\t</div>\r\n\t\t\t\t\t<div
+        class=\"clear\"></div>\r\n\t\t\t\t</div>\r\n\t\t\t</div>\r\n\t\t\t<div id=\"footerBottom\">\r\n\t\t\t
+        \   <div class=\"container\">\r\n\t\t\t        <div id=\"footercontent\"><p>&copy;
+        <script type=\"text/javascript\">document.write(new Date().getFullYear());</script>
+        Cardiff Council</p></div>\r\n\t\t\t        <div class=\"clear\"></div>\r\n\t\t\t
+        \   </div>\r\n\t\t\t</div>\r\n        </div>    \r\n    </div>  \r\n    <!--
+        IDOX PA END -->           \r\n\t\r\n</body>\r\n</html>\r\n\r\n"
+    http_version: 
+  recorded_at: Mon, 15 Apr 2019 11:13:36 GMT
+- request:
+    method: get
+    uri: https://planningonline.cardiff.gov.uk/online-applications/applicationDetails.do?activeTab=summary&keyVal=_CARDIFF_DCAPR_126851
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip,deflate,identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mechanize/2.7.6 Ruby/2.6.2p47 (http://github.com/sparklemotion/mechanize/)
+      Accept-Charset:
+      - ISO-8859-1,utf-8;q=0.7,*;q=0.7
+      Accept-Language:
+      - en-us,en;q=0.5
+      Cookie:
+      - JSESSIONID=ss9pKoHL32yHmhJQONSykek96zXCSSZ75skxJ5v1.vmidoxweblve; WSLang-CFC001=EN
+      Host:
+      - planningonline.cardiff.gov.uk
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '300'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - text/html; charset=UTF-8
+      Expires:
+      - Mon, 15 Apr 2019 11:14:20 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ua-Compatible:
+      - IE=edge
+      Server:
+      - Apache
+      Set-Cookie:
+      - WSLang-CFC001=EN; expires=Mon, 15-Apr-2069 11:14:17 GMT; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 15 Apr 2019 11:14:19 GMT
+      Content-Length:
+      - '28290'
+    body:
+      encoding: UTF-8
+      string: "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n    \n\n    \n\n<!DOCTYPE html PUBLIC
+        \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\r\n<html
+        lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\r\n<head>\r\n\t\r\n\t<!--
+        #BeginEditable \"doctitle\" -->\r\n    <title>\r\n    19/00552/MNR\r\n    |\r\n
+        \   \r\n        USE AS A (C4) 6 BEDROOM HOUSE IN MULTIPLE OCCUPATION\r\n        \r\n
+        \       |\r\n        \r\n    \r\n\r\n    \r\n\r\n    \r\n\r\n    \r\n    \r\n
+        \   \r\n    \r\n    \r\n        \r\n        47 ELM STREET, ROATH, CARDIFF,
+        CF24 3QS\r\n    \r\n    \r\n    </title>\r\n<!-- #EndEditable -->\r\n    <!--
+        #BeginEditable \"metatags\" --><!-- #EndEditable -->\r\n\t\r\n    <meta http-equiv=\"Content-Type\"
+        content=\"text/html; charset=UTF-8\" />\r\n\t\r\n\t<!-- Customer metatags
+        -->\r\n\t\r\n\t\r\n\t<!-- Favicon link -->\r\n    <link rel=\"icon\" href=\"/online-applications-skin/images/cardiff/favicon.ico\"
+        type=\"image/x-icon\" />\r\n\t\r\n    <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/screen.css\"
+        type=\"text/css\" media=\"screen,projection\" />\r\n    <link rel=\"stylesheet\"
+        href=\"/online-applications-skin/styles/theme1.css\" type=\"text/css\"/>    \r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/print.css\"
+        type=\"text/css\" media=\"print\" />\r\n\t\r\n    <script type=\"text/javascript\"
+        src=\"/online-applications-skin/scripts/jquery.min.js\"></script>\r\n    <script
+        type=\"text/javascript\" src=\"/online-applications-skin/scripts/jquery.toolbar.idox.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/common.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/checkbox.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/amplify.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/createCommentCookie.js\"></script>\r\n
+        \       \r\n\t<!-- Customer Analytics Script -->\r\n\t\r\n\t\r\n    <script
+        type=\"text/javascript\">\r\n    \t$('html').addClass('js');\r\n    \t$(document).ready(function(){\r\n
+        \   \t\t$('.main#apply>span:first-child').attr('tabindex', '0')\r\n    \t});\r\n
+        \   </script>\r\n    \r\n    <!-- #BeginEditable \"mobile\" --><!-- #EndEditable
+        -->\r\n    <!-- #BeginEditable \"head\" -->\r\n\t<script type=\"text/javascript\">\r\n\t
+        \   jQuery(document).ready(function() {\t\r\n\t\t\tjQuery('#pa').before('<img
+        src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\" id=\"preload\"
+        />');\r\n\t\t\tjQuery('#preload').hide();\r\n\t\t\tjQuery('.tabs a#tab_documents').click(
+        function(event) {\r\n\t\t\t\t  window.clearTimeout(window.timeOutId);\r\n\t\t\t\t
+        \ window.timeOutId = window.setTimeout(function() {\r\n\t\t\t\t\t\tjQuery('.content').before('<div
+        id=\"overlay\"></div><div id=\"loading\"><div id=\"message\">Loading. Please
+        wait.... <img src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\"
+        height=\"19\" width=\"220\" style=\"background:#fff;\" /></div></div>');\r\n\t\t\t\t
+        \ },10);\r\n\t\t\t\t});\r\n\t\t\tjQuery('p.associateddocument a').click( function(event)
+        {\r\n\t\t\t\t  window.clearTimeout(window.timeOutId);\r\n\t\t\t\t  window.timeOutId
+        = window.setTimeout(function() {\r\n\t\t\t\t\t\tjQuery('.content').before('<div
+        id=\"overlay\"></div><div id=\"loading\"><div id=\"message\">Loading. Please
+        wait.... <img src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\"
+        height=\"19\" width=\"220\" style=\"background:#fff;\" /></div></div>');\r\n\t\t\t\t
+        \ },10);\r\n\t\t\t\t});\r\n\r\n\t\t});\r\n    </script>\r\n    \r\n    <link
+        rel=\"stylesheet\" href=\"/online-applications-skin/styles/simple_social_share.min.css\"
+        type=\"text/css\"/>\r\n    <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/simple_social_share.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\">\r\n        $(document).ready(function(){\r\n
+        \           \r\n            \r\n            $(\"share-button\").simpleSocialShare({\r\n
+        \               sites: \"twitter,email\", \r\n                url: window.location.href,
+        \r\n                title: \"Online application\", \r\n                description:
+        \"Please look at this Planning Application: \", \r\n                shareType:
+        \"button\", \r\n                buttonSide: \"left\", \r\n                orientation:
+        \"horizontal\"\r\n            });\r\n        });\r\n\t</script>\r\n\t<!--
+        #EndEditable -->\r\n    <!-- #BeginEditable \"webapp\" --><!-- #EndEditable
+        -->\r\n\r\n</head>\r\n<body>\r\n\r\n    <a href=\"#pageheading\" class=\"sr-only\">Skip
+        to main content</a>\r\n\r\n    <!-- IDOX PA START -->\r\n    <div id=\"idox\">\r\n
+        \       <div id=\"pa\">\r\n\t\t\t<div id=\"header\"><!-- Selector: Selector
+        1 -->\r\n<style>\r\n#langStyle{float:right; margin-top: 10px; margin-right:
+        30px; background:transparent; font-size:13px; cursor:pointer; border:1px solid
+        #fff !important;border-radius:2px; z-index:999; background-color: #fff; padding:2px;}\r\n#langStyle:hover{text-decoration:
+        underline;}</style>\r\n<div>\r\n\r\n<!--CYS--><a id=\"langStyle\" href=\"/online-applications/applicationDetails.do?keyVal=_CARDIFF_DCAPR_126851&activeTab=summary&lang=CY\">Cymraeg</a><!--CYE-->\r\n</div>\r\n\t\t\t\t<div
+        class=\"container\">\r\n\t\t\t\t\t<div id=\"logo\"><a href=\"https://www.cardiff.gov.uk/\"
+        title=\"Cardiff Council home page\"><img src=\"/online-applications-skin/images/cardiff/logo.png\"
+        alt=\"Council logo\" /><span class=\"sr-only\">Cardiff Council</span></a></div>\r\n\t\t\t\t\t<div
+        id=\"headertitle\"><span></span></div>\r\n\t\t\t\t\t<div class=\"clear\"></div>\r\n\t\t\t\t</div>\t\r\n\t\t\t</div>\r\n\t\t\t<div
+        id=\"breadcrumbs\" class=\"container\">\r\n\t\t\t\t<ul>\r\n\t\t\t\t\t\r\n\t\t\t\t</ul>\r\n\t\t\t</div>\r\n
+        \           <div class=\"container\">\r\n       \t\t\t<div id=\"toolbar\"
+        class=\"nojs\">\r\n                    <ul>\t\r\n                        <li
+        id=\"search\" class=\"main\"><span tabindex=\"0\">Search&nbsp;</span><span
+        class=\"caret\"></span>\r\n   \t\t\t\t\t\t\t<ul>\t\r\n\t\t\t\t\t\t\t\t<!--
+        #BeginLibraryItem \"/Library/searchModulesNavItems.lbi\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \       \r\n            <li id=\"planLinks\">\r\n                <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\"
+        >\r\n                    <span>Planning</span>\r\n                </a>\r\n
+        \               <ul>\r\n                    <li id=\"planBasicSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\">\r\n
+        \                           Simple Search\r\n                        </a>\r\n
+        \                   </li>\r\n\r\n                    <li id=\"planAdvancedSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=advanced&amp;searchType=Application\">\r\n
+        \                           Advanced\r\n                        </a>\r\n                    </li>\r\n
+        \                   <li id=\"planListSearch\">\r\n                        <a
+        href=\"/online-applications/search.do?action=weeklyList&amp;searchType=Application\">\r\n
+        \                           Weekly/Monthly Lists\r\n                        </a>\r\n
+        \                   </li>\r\n                    <li id=\"planPropertySearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=property&amp;type=custom\">\r\n
+        \                           Property Search\r\n                        </a>\r\n
+        \                   </li>\r\n\t\t\t\t\t\r\n                    \r\n\t\t\t\t\t\r\n
+        \               </ul>\r\n            </li>\r\n        \r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        <!-- #EndLibraryItem -->\r\n                        \t</ul>\r\n\t\t\t\t\t\t</li>\r\n
+        \                       <!-- #BeginEditable \"applicationForms\" -->\n\n\n\n\n\n
+        \  \n<!-- #EndEditable -->   \t\t\t\t\r\n                        <li id=\"myprofile\"
+        class=\"main\"><span tabindex=\"0\">My Profile&nbsp;</span><span class=\"caret\"></span>\r\n
+        \                           <ul>\r\n                              <!-- #BeginLibraryItem
+        \"/Library/consulteeInTrayNavItem.lbi\" -->\n\n\n\n\n\n\n    <!-- #EndLibraryItem
+        -->\r\n                                <li><a href=\"/online-applications/registered/displayUserDetails.do\">Profile
+        Details</a></li>\r\n                                <li><a href=\"/online-applications/registered/savedSearch.do?action=display\">Saved
+        Searches</a></li>\r\n                                <li><a href=\"/online-applications/registered/userAdmin.do?action=showNotifiedApplications\">Notified
+        Applications</a></li>\r\n                                <li><a href=\"/online-applications/registered/trackedApplication.do?action=display\">Tracked
+        Applications</a></li>\r\n                                <!-- #BeginEditable
+        \"formSubmissions\" -->\n\n\n\n\n\n\n\n\n<!-- #EndEditable -->    \t\r\n                            </ul>\r\n
+        \                       </li>\r\n                        <li id=\"loginLink\"
+        class=\"main\"><!-- #BeginEditable \"loginlogout\" -->\n\n\n\n\n\n\n\n\n\n\n\t<a
+        href=\"/online-applications/registered/userAdmin.do\">Login</a>\n<!-- #EndEditable
+        --></li>\r\n                        <!-- #BeginEditable \"register\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \  \r\n\r\n\r\n\t<li id=\"register\">\r\n        <a href=\"/online-applications/registrationWizard.do?action=start\">Register</a>\r\n\t</li>\r\n\r\n<!--
+        #EndEditable -->\r\n                        <!-- #BeginLibraryItem \"/Library/applyOnlineNavItems.lbi\"
+        -->\r\n\r\n\r\n\r\n\r\n\r\n<!-- #EndLibraryItem -->\r\n                    </ul>\r\n
+        \   \t\t\t</div>\r\n\r\n    \t\t\t<!-- #BeginEditable \"headlinenews\" --><!--
+        #EndEditable -->\r\n                 \r\n                <div id=\"pageheading\">\r\n
+        \                   <h1><strong>Planning</strong>&nbsp;&ndash;&nbsp;<!-- #BeginEditable
+        \"pageheading\" -->Application Summary<!-- #EndEditable --></h1>\r\n                    <!--
+        #BeginEditable \"helplink\" -->\r\n<p class=\"pagehelp\">\r\n\t<a title=\"Help
+        with this page (opens in a new window)\" rel=\"external\" target=\"_blank\"
+        href=\"/online-applications/help/pagehelp/applications.htm\">\r\n\t\tHelp
+        with this page\r\n\t<span> (opens in a new window)</span>\r\n\t</a>\r\n</p>\r\n<!--
+        #EndEditable -->\r\n                </div>\r\n                \r\n                <!--
+        START WAM CONTENT -->\r\n                <div class=\"content\">\r\n                    <!--
+        #BeginEditable \"errormsg\" -->\n        \n        \n\n        \n        \n
+        \   <!-- #EndEditable -->\r\n                    <!-- #BeginEditable \"pagehead\"
+        -->\r\n\r\n    <div class=\"addressCrumb\">\r\n        <span class=\"caseNumber\">\r\n
+        \           \r\n\r\n            \r\n                19/00552/MNR\r\n            \r\n
+        \       </span>\r\n\r\n        <span class=\"divider1\">|</span>\r\n\r\n        \r\n
+        \           <span class=\"description\">\r\n                USE AS A (C4)
+        6 BEDROOM HOUSE IN MULTIPLE OCCUPATION\r\n            </span>\r\n            \r\n
+        \               <span class=\"divider2\">|</span>\r\n            \r\n        \r\n\r\n
+        \       \r\n\r\n        \r\n\r\n        \r\n        \r\n        \r\n        \r\n
+        \       \r\n            \r\n            <span class=\"address\">\r\n                47
+        ELM STREET, ROATH, CARDIFF, CF24 3QS\r\n            </span>\r\n        \r\n
+        \       \r\n    </div>\r\n\r\n\r\n    <div id=\"applicationTools\">\r\n        <ul>\r\n
+        \           \r\n            \r\n                \r\n                    \r\n
+        \                       \r\n                            \r\n                            \r\n
+        \                               \r\n                                    <li>\r\n
+        \                                       <a href=\"/online-applications/searchResultsBack.do?action=back\"
+        id=\"searchresultsback\">Back to search results</a>\r\n                                    </li>\r\n
+        \                               \r\n                            \r\n                        \r\n
+        \                   \r\n                    \r\n                    \r\n                \r\n
+        \           \r\n\r\n            \r\n\r\n            \r\n            \r\n\r\n
+        \           \r\n\r\n            \r\n            \r\n                \r\n                    <li>\r\n
+        \                       <form name=\"trackForm\" method=\"post\" action=\"/online-applications/registered/trackedApplicationSubmit.do?action=track\"><input
+        type=\"hidden\" name=\"org.apache.struts.taglib.html.TOKEN\" value=\"40fc624504cdd9313320de904cf21743\"
+        />\r\n                            <input type=\"hidden\" name=\"caseNo\" value=\"19/00552/MNR\"
+        />\r\n                            <input type=\"hidden\" name=\"caseType\"
+        value=\"Application\" />\r\n                            <input type=\"hidden\"
+        name=\"address\" value=\"47 ELM STREET, ROATH, CARDIFF, CF24 3QS\" />\r\n
+        \                           <input type=\"hidden\" name=\"description\" value=\"USE
+        AS A (C4) 6 BEDROOM HOUSE IN MULTIPLE OCCUPATION\" />\r\n                            <input
+        type=\"hidden\" name=\"status\" value=\"Withdrawn\" />\r\n                            <input
+        type=\"hidden\" name=\"trackingStatus\" value=\"Withdrawn\" />\r\n                            <input
+        type=\"hidden\" name=\"caseTechnicalKey\" value=\"_CARDIFF_DCAPR_126851\"
+        />\r\n                            <input class=\"casefiletrack\"\r\n                                   src=\"/online-applications-skin/images/button_track.gif\"\r\n
+        \                                  type=\"image\"\r\n                                   name=\"submit\"\r\n
+        \                                  altKey=\"casedetails.track\"\r\n                                   title=\"Get
+        informed when this item is updated\"/>\r\n                        </form>\r\n
+        \                   </li>\r\n                \r\n\r\n                \r\n
+        \           \r\n\r\n\r\n            \r\n                \r\n             \r\n
+        \           \r\n\r\n            \r\n            \r\n                \r\n            \r\n
+        \           \r\n            \r\n            <li>\r\n                <a href=\"/online-applications/applicationDetails.do?activeTab=printPreview&amp;keyVal=_CARDIFF_DCAPR_126851\"
+        id=\"print\" rel=\"external\">\r\n                    <img src=\"/online-applications-skin/images/button_print.gif\"
+        alt=\"Print summary icon\" width=\"53\" height=\"22\" border=\"0\"/>\r\n                </a>\r\n
+        \           </li>\r\n            \r\n\r\n            \r\n        </ul>\r\n\r\n
+        \   </div>\r\n\r\n\r\n     \r\n\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabs\" -->\r\n    \r\n    <ul class=\"tabs\">\r\n\r\n        \r\n\r\n
+        \           \r\n                \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/applicationDetails.do?activeTab=summary&amp;keyVal=_CARDIFF_DCAPR_126851\"
+        id=\"tab_summary\" class=\"active\">\r\n                        <span>\r\n
+        \                           Details\r\n                            \r\n                        </span>\r\n
+        \                   </a>\r\n\r\n                    \r\n                    \r\n
+        \                   \r\n                        \r\n                        \r\n\r\n
+        \                           <ul class=\"subtabs\">\r\n                                \r\n
+        \                                   \r\n                                        <li>\r\n
+        \                                           \r\n                                            <a
+        href=\"/online-applications/applicationDetails.do?activeTab=summary&amp;keyVal=_CARDIFF_DCAPR_126851\"
+        id=\"subtab_summary\" class=\"active\">\r\n                                                <span>\r\n
+        \                                                   Summary\r\n                                                    \r\n
+        \                                               </span>\r\n                                            </a>\r\n
+        \                                       </li>\r\n                                    \r\n
+        \                               \r\n                                    \r\n
+        \                                       <li>\r\n                                            \r\n
+        \                                           <a href=\"/online-applications/applicationDetails.do?activeTab=details&amp;keyVal=_CARDIFF_DCAPR_126851\"
+        id=\"subtab_details\">\r\n                                                <span>\r\n
+        \                                                   Further Information\r\n
+        \                                                   \r\n                                                </span>\r\n
+        \                                           </a>\r\n                                        </li>\r\n
+        \                                   \r\n                                \r\n
+        \                                   \r\n                                        <li>\r\n
+        \                                           \r\n                                            <a
+        href=\"/online-applications/applicationDetails.do?activeTab=contacts&amp;keyVal=_CARDIFF_DCAPR_126851\"
+        id=\"subtab_contacts\">\r\n                                                <span>\r\n
+        \                                                   Contacts\r\n                                                    \r\n
+        \                                               </span>\r\n                                            </a>\r\n
+        \                                       </li>\r\n                                    \r\n
+        \                               \r\n                                    \r\n
+        \                                       <li>\r\n                                            \r\n
+        \                                           <a href=\"/online-applications/applicationDetails.do?activeTab=dates&amp;keyVal=_CARDIFF_DCAPR_126851\"
+        id=\"subtab_dates\">\r\n                                                <span>\r\n
+        \                                                   Important Dates\r\n                                                    \r\n
+        \                                               </span>\r\n                                            </a>\r\n
+        \                                       </li>\r\n                                    \r\n
+        \                               \r\n                            </ul>\r\n\r\n
+        \                       \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n                \r\n
+        \               <li>\r\n\r\n                     \r\n                    <a
+        href=\"/online-applications/applicationDetails.do?activeTab=makeComment&amp;keyVal=_CARDIFF_DCAPR_126851\"
+        id=\"tab_makeComment\">\r\n                        <span>\r\n                            Comments\r\n
+        \                           \r\n                                \r\n                                (0)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n\r\n
+        \           \r\n                <li class=\"nodocuments\">\r\n                    <span>\r\n
+        \                       Constraints\r\n                        \r\n                            \r\n
+        \                           (0)\r\n                        \r\n                    </span>\r\n
+        \               </li>\r\n            \r\n\r\n        \r\n\r\n            \r\n
+        \               \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/applicationDetails.do?activeTab=documents&amp;keyVal=_CARDIFF_DCAPR_126851\"
+        id=\"tab_documents\">\r\n                        <span>\r\n                            Documents\r\n
+        \                           \r\n                                \r\n                                (8)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n                \r\n
+        \               <li>\r\n\r\n                     \r\n                    <a
+        href=\"/online-applications/applicationDetails.do?activeTab=relatedCases&amp;keyVal=_CARDIFF_DCAPR_126851\"
+        id=\"tab_relatedCases\">\r\n                        <span>\r\n                            Related
+        Cases\r\n                            \r\n                                \r\n
+        \                               (1)\r\n                            \r\n                        </span>\r\n
+        \                   </a>\r\n\r\n                    \r\n                    \r\n
+        \                   \r\n                </li>\r\n            \r\n\r\n            \r\n\r\n
+        \       \r\n\r\n            \r\n\r\n            \r\n\r\n        \r\n    </ul>\r\n<!--
+        #EndEditable -->\r\n                    <!-- #BeginEditable \"tabsubnav\"
+        --><!-- #EndEditable -->\r\n                    <!-- #BeginEditable \"pagebody\"
+        -->\n    \r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\n
+        \   \n        \n        \n    \n\n    \n    \n    \n    \n    \n\n    <div
+        class=\"tabcontainer\">\n\n        \n        \n        \n\n        \n        \n\n
+        \           \n            \n                \n            \n\n            \n
+        \               <table id=\"simpleDetailsTable\" summary=\"Case Details\">\n\n
+        \                   \n                    \n                        \n                            <tr>\n
+        \                               <th scope=\"row\" width=\"40%\">\n                                    Reference\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            19/00552/MNR\n
+        \                                       \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Alternative Reference\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            PP-07686229\n
+        \                                       \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Application Received\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            Thu
+        07 Mar 2019\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Application Validated\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            Thu
+        21 Mar 2019\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Address\n                                </th>\n
+        \                               <td>\n                                    \n
+        \                                       \n                                        \n
+        \                                           47 ELM STREET, ROATH, CARDIFF,
+        CF24 3QS\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Proposal\n                                </th>\n
+        \                               <td>\n                                    \n
+        \                                       \n                                        \n
+        \                                           USE AS A (C4) 6 BEDROOM HOUSE
+        IN MULTIPLE OCCUPATION\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Status\n                                </th>\n
+        \                               <td>\n                                    \n
+        \                                       \n                                            <span
+        class=\"caseDetailsStatus\">Withdrawn</span>\n                                        \n
+        \                                       \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Decision\n                                </th>\n
+        \                               <td>\n                                    \n
+        \                                       \n                                        \n
+        \                                           Withdrawn by Applicant\n                                        \n
+        \                                   \n                                </td>\n
+        \                           </tr>\n                        \n                    \n
+        \                       \n                            <tr>\n                                <th
+        scope=\"row\" width=\"40%\">\n                                    Decision
+        Issued Date\n                                </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            Mon
+        08 Apr 2019\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Appeal Decision\n                                </th>\n
+        \                               <td>\n                                    \n
+        \                                       \n                                        \n
+        \                                           \n                                        \n
+        \                                   \n                                </td>\n
+        \                           </tr>\n                        \n                    \n\n
+        \               </table>\n\n                \n                \n\n                \n\n
+        \           \n\n            \n\n        \n\n        \n        \n            \n
+        \               <div id=\"summaryInfo\">\n                    \n                    \n
+        \                   \n                        \n                            \n
+        \                       \n                    \n\n                    \n                    \n
+        \                       <p class=\"associateddocument\">There are <a href=\"/online-applications/applicationDetails.do?activeTab=documents&amp;keyVal=_CARDIFF_DCAPR_126851\">8
+        documents</a> associated with this application.</p><p class=\"associatedcase\">There
+        are 0 cases associated with this application.</p><p class=\"associatedproperty\">There
+        is <a href=\"/online-applications/applicationDetails.do?activeTab=relatedCases&amp;keyVal=_CARDIFF_DCAPR_126851\">1
+        property</a> associated with this application.</p>\r\n\n                    \n
+        \               </div>\n            \n        \n\n    </div>\n<!-- #EndEditable
+        -->\r\n                    <!-- #BeginEditable \"pagefoot\" --><!-- #EndEditable
+        -->\r\n                </div>\r\n                <!-- END WAM CONTENT -->\r\n
+        \               \r\n                <p id=\"poweredBy\"><a href=\"http://www.idoxgroup.com/\"
+        target=\"_blank\" title=\"This link will open a new window\"><img src=\"/online-applications-skin/images/idox.gif\"
+        alt=\"an Idox solution\" /></a></p>\r\n            </div>\t\r\n\t\t\t<div
+        id=\"footer\">\r\n\t\t\t\t<div class=\"container\">\t\t\t\t\t\r\n\t\t\t\t\t<div
+        id=\"links\">\r\n\t\t\t\t\t\t<ul>\r\n\t\t\t\t\t\t\t<li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Site_Map/Pages/default.aspx\">Site
+        map</a></li><li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Cookies/Pages/Cookies.aspx\">Cookies</a></li><li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/New_Disclaimer/Pages/default.aspx\">Disclaimer</a></li>\r\n\t\t\t\t\t\t</ul>\r\n\t\t\t\t\t</div>\r\n\t\t\t\t\t<div
+        class=\"clear\"></div>\r\n\t\t\t\t</div>\r\n\t\t\t</div>\r\n\t\t\t<div id=\"footerBottom\">\r\n\t\t\t
+        \   <div class=\"container\">\r\n\t\t\t        <div id=\"footercontent\"><p>&copy;
+        <script type=\"text/javascript\">document.write(new Date().getFullYear());</script>
+        Cardiff Council</p></div>\r\n\t\t\t        <div class=\"clear\"></div>\r\n\t\t\t
+        \   </div>\r\n\t\t\t</div>\r\n        </div>    \r\n    </div>  \r\n    <!--
+        IDOX PA END -->           \r\n\t\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Mon, 15 Apr 2019 11:13:49 GMT
+- request:
+    method: get
+    uri: https://planningonline.cardiff.gov.uk/online-applications/applicationDetails.do?activeTab=relatedCases&keyVal=_CARDIFF_DCAPR_126851
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip,deflate,identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mechanize/2.7.6 Ruby/2.6.2p47 (http://github.com/sparklemotion/mechanize/)
+      Accept-Charset:
+      - ISO-8859-1,utf-8;q=0.7,*;q=0.7
+      Accept-Language:
+      - en-us,en;q=0.5
+      Cookie:
+      - JSESSIONID=ss9pKoHL32yHmhJQONSykek96zXCSSZ75skxJ5v1.vmidoxweblve; WSLang-CFC001=EN
+      Host:
+      - planningonline.cardiff.gov.uk
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '300'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - text/html; charset=UTF-8
+      Expires:
+      - Mon, 15 Apr 2019 11:14:22 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ua-Compatible:
+      - IE=edge
+      Server:
+      - Apache
+      Set-Cookie:
+      - WSLang-CFC001=EN; expires=Mon, 15-Apr-2069 11:14:21 GMT; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 15 Apr 2019 11:14:22 GMT
+      Content-Length:
+      - '19897'
+    body:
+      encoding: UTF-8
+      string: "\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n<!DOCTYPE
+        html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\r\n<html
+        lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\r\n<head>\r\n\t\r\n\t<!--
+        #BeginEditable \"doctitle\" -->\r\n    <title>\r\n    19/00552/MNR\r\n    |\r\n
+        \   \r\n        USE AS A (C4) 6 BEDROOM HOUSE IN MULTIPLE OCCUPATION\r\n        \r\n
+        \       |\r\n        \r\n    \r\n\r\n    \r\n\r\n    \r\n\r\n    \r\n    \r\n
+        \   \r\n    \r\n    \r\n        \r\n        47 ELM STREET, ROATH, CARDIFF,
+        CF24 3QS\r\n    \r\n    \r\n    </title>\r\n<!-- #EndEditable -->\r\n    <!--
+        #BeginEditable \"metatags\" --><!-- #EndEditable -->\r\n\t\r\n    <meta http-equiv=\"Content-Type\"
+        content=\"text/html; charset=UTF-8\" />\r\n\t\r\n\t<!-- Customer metatags
+        -->\r\n\t\r\n\t\r\n\t<!-- Favicon link -->\r\n    <link rel=\"icon\" href=\"/online-applications-skin/images/cardiff/favicon.ico\"
+        type=\"image/x-icon\" />\r\n\t\r\n    <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/screen.css\"
+        type=\"text/css\" media=\"screen,projection\" />\r\n    <link rel=\"stylesheet\"
+        href=\"/online-applications-skin/styles/theme1.css\" type=\"text/css\"/>    \r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/print.css\"
+        type=\"text/css\" media=\"print\" />\r\n\t\r\n    <script type=\"text/javascript\"
+        src=\"/online-applications-skin/scripts/jquery.min.js\"></script>\r\n    <script
+        type=\"text/javascript\" src=\"/online-applications-skin/scripts/jquery.toolbar.idox.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/common.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/checkbox.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/amplify.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/createCommentCookie.js\"></script>\r\n
+        \       \r\n\t<!-- Customer Analytics Script -->\r\n\t\r\n\t\r\n    <script
+        type=\"text/javascript\">\r\n    \t$('html').addClass('js');\r\n    \t$(document).ready(function(){\r\n
+        \   \t\t$('.main#apply>span:first-child').attr('tabindex', '0')\r\n    \t});\r\n
+        \   </script>\r\n    \r\n    <!-- #BeginEditable \"mobile\" --><!-- #EndEditable
+        -->\r\n    <!-- #BeginEditable \"head\" --><!-- #EndEditable -->\r\n    <!--
+        #BeginEditable \"webapp\" -->\r\n\t<script type=\"text/javascript\">\r\n\t
+        \   jQuery(document).ready(function() {\t\t\r\n\t\t\tjQuery('#pa').before('<img
+        src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\" id=\"preload\"
+        />');\r\n\t\t\tjQuery('#preload').hide();\r\n\t\t\tjQuery('.tabs a#tab_documents').click(
+        function(event) {\r\n\t\t\t\t  window.clearTimeout(window.timeOutId);\r\n\t\t\t\t
+        \ window.timeOutId = window.setTimeout(function() {\r\n\t\t\t\t\t\tjQuery('.content').before('<div
+        id=\"overlay\"></div><div id=\"loading\"><div id=\"message\">Loading. Please
+        wait.... <img src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\"
+        height=\"19\" width=\"220\" style=\"background:#fff;\" /></div></div>');\r\n\t\t\t\t
+        \ },10); \r\n\t\t\t\t});\r\n\t\t\t\t\r\n\t\t});\r\n\t</script>\r\n            \r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/simple_social_share.min.css\"
+        type=\"text/css\"/>\r\n    <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/simple_social_share.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\">\r\n        $(document).ready(function(){\r\n
+        \           \r\n            \r\n            $(\"share-button\").simpleSocialShare({\r\n
+        \               sites: \"twitter,email\", \r\n                url: window.location.href,
+        \r\n                title: \"Online application\", \r\n                description:
+        \"Please look at this Planning Application: \", \r\n                shareType:
+        \"button\", \r\n                buttonSide: \"left\", \r\n                orientation:
+        \"horizontal\"\r\n            });\r\n        });\r\n\t</script>\r\n\t<!--
+        #EndEditable -->\r\n\r\n</head>\r\n<body>\r\n\r\n    <a href=\"#pageheading\"
+        class=\"sr-only\">Skip to main content</a>\r\n\r\n    <!-- IDOX PA START -->\r\n
+        \   <div id=\"idox\">\r\n        <div id=\"pa\">\r\n\t\t\t<div id=\"header\"><!--
+        Selector: Selector 1 -->\r\n<style>\r\n#langStyle{float:right; margin-top:
+        10px; margin-right: 30px; background:transparent; font-size:13px; cursor:pointer;
+        border:1px solid #fff !important;border-radius:2px; z-index:999; background-color:
+        #fff; padding:2px;}\r\n#langStyle:hover{text-decoration: underline;}</style>\r\n<div>\r\n\r\n<!--CYS--><a
+        id=\"langStyle\" href=\"/online-applications/applicationDetails.do?activeTab=relatedCases&keyVal=_CARDIFF_DCAPR_126851&lang=CY\">Cymraeg</a><!--CYE-->\r\n</div>\r\n\t\t\t\t<div
+        class=\"container\">\r\n\t\t\t\t\t<div id=\"logo\"><a href=\"https://www.cardiff.gov.uk/\"
+        title=\"Cardiff Council home page\"><img src=\"/online-applications-skin/images/cardiff/logo.png\"
+        alt=\"Council logo\" /><span class=\"sr-only\">Cardiff Council</span></a></div>\r\n\t\t\t\t\t<div
+        id=\"headertitle\"><span></span></div>\r\n\t\t\t\t\t<div class=\"clear\"></div>\r\n\t\t\t\t</div>\t\r\n\t\t\t</div>\r\n\t\t\t<div
+        id=\"breadcrumbs\" class=\"container\">\r\n\t\t\t\t<ul>\r\n\t\t\t\t\t\r\n\t\t\t\t</ul>\r\n\t\t\t</div>\r\n
+        \           <div class=\"container\">\r\n       \t\t\t<div id=\"toolbar\"
+        class=\"nojs\">\r\n                    <ul>\t\r\n                        <li
+        id=\"search\" class=\"main\"><span tabindex=\"0\">Search&nbsp;</span><span
+        class=\"caret\"></span>\r\n   \t\t\t\t\t\t\t<ul>\t\r\n\t\t\t\t\t\t\t\t<!--
+        #BeginLibraryItem \"/Library/searchModulesNavItems.lbi\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \       \r\n            <li id=\"planLinks\">\r\n                <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\"
+        >\r\n                    <span>Planning</span>\r\n                </a>\r\n
+        \               <ul>\r\n                    <li id=\"planBasicSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\">\r\n
+        \                           Simple Search\r\n                        </a>\r\n
+        \                   </li>\r\n\r\n                    <li id=\"planAdvancedSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=advanced&amp;searchType=Application\">\r\n
+        \                           Advanced\r\n                        </a>\r\n                    </li>\r\n
+        \                   <li id=\"planListSearch\">\r\n                        <a
+        href=\"/online-applications/search.do?action=weeklyList&amp;searchType=Application\">\r\n
+        \                           Weekly/Monthly Lists\r\n                        </a>\r\n
+        \                   </li>\r\n                    <li id=\"planPropertySearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=property&amp;type=custom\">\r\n
+        \                           Property Search\r\n                        </a>\r\n
+        \                   </li>\r\n\t\t\t\t\t\r\n                    \r\n\t\t\t\t\t\r\n
+        \               </ul>\r\n            </li>\r\n        \r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        <!-- #EndLibraryItem -->\r\n                        \t</ul>\r\n\t\t\t\t\t\t</li>\r\n
+        \                       <!-- #BeginEditable \"applicationForms\" -->\n\n\n\n\n\n
+        \  \n<!-- #EndEditable -->   \t\t\t\t\r\n                        <li id=\"myprofile\"
+        class=\"main\"><span tabindex=\"0\">My Profile&nbsp;</span><span class=\"caret\"></span>\r\n
+        \                           <ul>\r\n                              <!-- #BeginLibraryItem
+        \"/Library/consulteeInTrayNavItem.lbi\" -->\n\n\n\n\n\n\n    <!-- #EndLibraryItem
+        -->\r\n                                <li><a href=\"/online-applications/registered/displayUserDetails.do\">Profile
+        Details</a></li>\r\n                                <li><a href=\"/online-applications/registered/savedSearch.do?action=display\">Saved
+        Searches</a></li>\r\n                                <li><a href=\"/online-applications/registered/userAdmin.do?action=showNotifiedApplications\">Notified
+        Applications</a></li>\r\n                                <li><a href=\"/online-applications/registered/trackedApplication.do?action=display\">Tracked
+        Applications</a></li>\r\n                                <!-- #BeginEditable
+        \"formSubmissions\" -->\n\n\n\n\n\n\n\n\n<!-- #EndEditable -->    \t\r\n                            </ul>\r\n
+        \                       </li>\r\n                        <li id=\"loginLink\"
+        class=\"main\"><!-- #BeginEditable \"loginlogout\" -->\n\n\n\n\n\n\n\n\n\n\n\t<a
+        href=\"/online-applications/registered/userAdmin.do\">Login</a>\n<!-- #EndEditable
+        --></li>\r\n                        <!-- #BeginEditable \"register\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \  \r\n\r\n\r\n\t<li id=\"register\">\r\n        <a href=\"/online-applications/registrationWizard.do?action=start\">Register</a>\r\n\t</li>\r\n\r\n<!--
+        #EndEditable -->\r\n                        <!-- #BeginLibraryItem \"/Library/applyOnlineNavItems.lbi\"
+        -->\r\n\r\n\r\n\r\n\r\n\r\n<!-- #EndLibraryItem -->\r\n                    </ul>\r\n
+        \   \t\t\t</div>\r\n\r\n    \t\t\t<!-- #BeginEditable \"headlinenews\" --><!--
+        #EndEditable -->\r\n                 \r\n                <div id=\"pageheading\">\r\n
+        \                   <h1><strong>Planning</strong>&nbsp;&ndash;&nbsp;<!-- #BeginEditable
+        \"pageheading\" -->Application Related Items<!-- #EndEditable --></h1>\r\n
+        \                   <!-- #BeginEditable \"helplink\" -->\r\n<p class=\"pagehelp\">\r\n\t<a
+        title=\"Help with this page (opens in a new window)\" rel=\"external\" target=\"_blank\"
+        href=\"/online-applications/help/pagehelp/applications.htm\">\r\n\t\tHelp
+        with this page\r\n\t<span> (opens in a new window)</span>\r\n\t</a>\r\n</p>\r\n<!--
+        #EndEditable -->\r\n                </div>\r\n                \r\n                <!--
+        START WAM CONTENT -->\r\n                <div class=\"content\">\r\n                    <!--
+        #BeginEditable \"errormsg\" --><!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"pagehead\" -->\r\n\r\n    <div class=\"addressCrumb\">\r\n
+        \       <span class=\"caseNumber\">\r\n            \r\n\r\n            \r\n
+        \               19/00552/MNR\r\n            \r\n        </span>\r\n\r\n        <span
+        class=\"divider1\">|</span>\r\n\r\n        \r\n            <span class=\"description\">\r\n
+        \               USE AS A (C4) 6 BEDROOM HOUSE IN MULTIPLE OCCUPATION\r\n            </span>\r\n
+        \           \r\n                <span class=\"divider2\">|</span>\r\n            \r\n
+        \       \r\n\r\n        \r\n\r\n        \r\n\r\n        \r\n        \r\n        \r\n
+        \       \r\n        \r\n            \r\n            <span class=\"address\">\r\n
+        \               47 ELM STREET, ROATH, CARDIFF, CF24 3QS\r\n            </span>\r\n
+        \       \r\n        \r\n    </div>\r\n\r\n\r\n    <div id=\"applicationTools\">\r\n
+        \       <ul>\r\n            \r\n            \r\n                \r\n                    \r\n
+        \                       \r\n                            \r\n                            \r\n
+        \                               \r\n                                    <li>\r\n
+        \                                       <a href=\"/online-applications/searchResultsBack.do?action=back\"
+        id=\"searchresultsback\">Back to search results</a>\r\n                                    </li>\r\n
+        \                               \r\n                            \r\n                        \r\n
+        \                   \r\n                    \r\n                    \r\n                \r\n
+        \           \r\n\r\n            \r\n\r\n            \r\n            \r\n\r\n
+        \           \r\n\r\n            \r\n            \r\n                \r\n                    <li>\r\n
+        \                       <form name=\"trackForm\" method=\"post\" action=\"/online-applications/registered/trackedApplicationSubmit.do?action=track\"><input
+        type=\"hidden\" name=\"org.apache.struts.taglib.html.TOKEN\" value=\"40fc624504cdd9313320de904cf21743\"
+        />\r\n                            <input type=\"hidden\" name=\"caseNo\" value=\"19/00552/MNR\"
+        />\r\n                            <input type=\"hidden\" name=\"caseType\"
+        value=\"Application\" />\r\n                            <input type=\"hidden\"
+        name=\"address\" value=\"47 ELM STREET, ROATH, CARDIFF, CF24 3QS\" />\r\n
+        \                           <input type=\"hidden\" name=\"description\" value=\"USE
+        AS A (C4) 6 BEDROOM HOUSE IN MULTIPLE OCCUPATION\" />\r\n                            <input
+        type=\"hidden\" name=\"status\" value=\"Withdrawn\" />\r\n                            <input
+        type=\"hidden\" name=\"trackingStatus\" value=\"Withdrawn\" />\r\n                            <input
+        type=\"hidden\" name=\"caseTechnicalKey\" value=\"_CARDIFF_DCAPR_126851\"
+        />\r\n                            <input class=\"casefiletrack\"\r\n                                   src=\"/online-applications-skin/images/button_track.gif\"\r\n
+        \                                  type=\"image\"\r\n                                   name=\"submit\"\r\n
+        \                                  altKey=\"casedetails.track\"\r\n                                   title=\"Get
+        informed when this item is updated\"/>\r\n                        </form>\r\n
+        \                   </li>\r\n                \r\n\r\n                \r\n
+        \           \r\n\r\n\r\n            \r\n                \r\n             \r\n
+        \           \r\n\r\n            \r\n            \r\n                \r\n            \r\n
+        \           \r\n            \r\n            <li>\r\n                <a href=\"/online-applications/applicationDetails.do?activeTab=printPreview&amp;keyVal=_CARDIFF_DCAPR_126851\"
+        id=\"print\" rel=\"external\">\r\n                    <img src=\"/online-applications-skin/images/button_print.gif\"
+        alt=\"Print summary icon\" width=\"53\" height=\"22\" border=\"0\"/>\r\n                </a>\r\n
+        \           </li>\r\n            \r\n\r\n            \r\n        </ul>\r\n\r\n
+        \   </div>\r\n\r\n\r\n     \r\n\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabs\" -->\r\n    \r\n    <ul class=\"tabs\">\r\n\r\n        \r\n\r\n
+        \           \r\n                \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/applicationDetails.do?activeTab=summary&amp;keyVal=_CARDIFF_DCAPR_126851\"
+        id=\"tab_summary\">\r\n                        <span>\r\n                            Details\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n                \r\n
+        \               <li>\r\n\r\n                     \r\n                    <a
+        href=\"/online-applications/applicationDetails.do?activeTab=makeComment&amp;keyVal=_CARDIFF_DCAPR_126851\"
+        id=\"tab_makeComment\">\r\n                        <span>\r\n                            Comments\r\n
+        \                           \r\n                                \r\n                                (0)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n\r\n
+        \           \r\n                <li class=\"nodocuments\">\r\n                    <span>\r\n
+        \                       Constraints\r\n                        \r\n                            \r\n
+        \                           (0)\r\n                        \r\n                    </span>\r\n
+        \               </li>\r\n            \r\n\r\n        \r\n\r\n            \r\n
+        \               \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/applicationDetails.do?activeTab=documents&amp;keyVal=_CARDIFF_DCAPR_126851\"
+        id=\"tab_documents\">\r\n                        <span>\r\n                            Documents\r\n
+        \                           \r\n                                \r\n                                (8)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n                \r\n
+        \               <li>\r\n\r\n                     \r\n                    <a
+        href=\"/online-applications/applicationDetails.do?activeTab=relatedCases&amp;keyVal=_CARDIFF_DCAPR_126851\"
+        id=\"tab_relatedCases\" class=\"active\">\r\n                        <span>\r\n
+        \                           Related Cases\r\n                            \r\n
+        \                               \r\n                                (1)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                        \r\n
+        \                       \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n\r\n
+        \           \r\n\r\n        \r\n    </ul>\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabsubnav\" --><!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"pagebody\" -->\r\n\r\n    \r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \   <div class=\"tabcontainer toplevel\">\r\n    <div id=\"relatedItems\">\r\n\r\n
+        \       \r\n            \r\n            \r\n\r\n            <!-- Display header
+        -->\r\n            <div id=\"Application\">\r\n                <h3>\r\n                    \r\n
+        \                   \r\n                        Planning Applications\r\n
+        \                   \r\n                    <span>(0)</span>\r\n                </h3>\n\r\n\r\n
+        \               <!-- Display each item -->\r\n                \r\n            </div>\r\n\r\n
+        \       \r\n            \r\n            \r\n\r\n            <!-- Display header
+        -->\r\n            <div id=\"Appeal\">\r\n                <h3>\r\n                    \r\n
+        \                   \r\n                        Planning Appeals\r\n                    \r\n
+        \                   <span>(0)</span>\r\n                </h3>\n\r\n\r\n                <!--
+        Display each item -->\r\n                \r\n            </div>\r\n\r\n        \r\n
+        \           \r\n            \r\n\r\n            <!-- Display header -->\r\n
+        \           <div id=\"Enforcement\">\r\n                <h3>\r\n                    \r\n
+        \                   \r\n                        Planning Enforcements\r\n
+        \                   \r\n                    <span>(0)</span>\r\n                </h3>\n\r\n\r\n
+        \               <!-- Display each item -->\r\n                \r\n            </div>\r\n\r\n
+        \       \r\n            \r\n            \r\n\r\n            <!-- Display header
+        -->\r\n            <div id=\"Property\">\r\n                <h3>\r\n                    \r\n
+        \                   \r\n                        Properties\r\n                    \r\n
+        \                   <span>(1)</span>\r\n                </h3>\n\r\n\r\n                <!--
+        Display each item -->\r\n                \r\n                    <ul>\r\n
+        \                       \r\n                            <li>\r\n                                \r\n
+        \                               \r\n                                \r\n\r\n
+        \                               <a href=\"/online-applications/propertyDetails.do?previousCaseType=Application&amp;keyVal=_CARDIFF_PROPLPI_100422_1&amp;previousCaseNumber=19%2F00552%2FMNR&amp;activeTab=summary&amp;previousKeyVal=_CARDIFF_DCAPR_126851\">\r\n
+        \                                   47 ELM STREET, ROATH, CARDIFF, CF24 3QS\r\n
+        \                               </a>\r\n\r\n                                <p
+        class=\"metaInfo\">\r\n\r\n                                \r\n\r\n                                \r\n\r\n
+        \                               \r\n                                \r\n                                \r\n
+        \                              </p>\r\n                            </li>\r\n
+        \                       \r\n                    </ul>\r\n                \r\n
+        \           </div>\r\n\r\n        \r\n\r\n    </div>\r\n    </div>\r\n\r\n<!--
+        #EndEditable -->\r\n                    <!-- #BeginEditable \"pagefoot\" --><!--
+        #EndEditable -->\r\n                </div>\r\n                <!-- END WAM
+        CONTENT -->\r\n                \r\n                <p id=\"poweredBy\"><a
+        href=\"http://www.idoxgroup.com/\" target=\"_blank\" title=\"This link will
+        open a new window\"><img src=\"/online-applications-skin/images/idox.gif\"
+        alt=\"an Idox solution\" /></a></p>\r\n            </div>\t\r\n\t\t\t<div
+        id=\"footer\">\r\n\t\t\t\t<div class=\"container\">\t\t\t\t\t\r\n\t\t\t\t\t<div
+        id=\"links\">\r\n\t\t\t\t\t\t<ul>\r\n\t\t\t\t\t\t\t<li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Site_Map/Pages/default.aspx\">Site
+        map</a></li><li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Cookies/Pages/Cookies.aspx\">Cookies</a></li><li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/New_Disclaimer/Pages/default.aspx\">Disclaimer</a></li>\r\n\t\t\t\t\t\t</ul>\r\n\t\t\t\t\t</div>\r\n\t\t\t\t\t<div
+        class=\"clear\"></div>\r\n\t\t\t\t</div>\r\n\t\t\t</div>\r\n\t\t\t<div id=\"footerBottom\">\r\n\t\t\t
+        \   <div class=\"container\">\r\n\t\t\t        <div id=\"footercontent\"><p>&copy;
+        <script type=\"text/javascript\">document.write(new Date().getFullYear());</script>
+        Cardiff Council</p></div>\r\n\t\t\t        <div class=\"clear\"></div>\r\n\t\t\t
+        \   </div>\r\n\t\t\t</div>\r\n        </div>    \r\n    </div>  \r\n    <!--
+        IDOX PA END -->           \r\n\t\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Mon, 15 Apr 2019 11:13:51 GMT
+- request:
+    method: get
+    uri: https://planningonline.cardiff.gov.uk/online-applications/propertyDetails.do?activeTab=summary&keyVal=_CARDIFF_PROPLPI_100422_1&previousCaseNumber=19/00552/MNR&previousCaseType=Application&previousKeyVal=_CARDIFF_DCAPR_126851
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip,deflate,identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mechanize/2.7.6 Ruby/2.6.2p47 (http://github.com/sparklemotion/mechanize/)
+      Accept-Charset:
+      - ISO-8859-1,utf-8;q=0.7,*;q=0.7
+      Accept-Language:
+      - en-us,en;q=0.5
+      Cookie:
+      - JSESSIONID=ss9pKoHL32yHmhJQONSykek96zXCSSZ75skxJ5v1.vmidoxweblve; WSLang-CFC001=EN
+      Host:
+      - planningonline.cardiff.gov.uk
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '300'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - text/html; charset=UTF-8
+      Expires:
+      - Mon, 15 Apr 2019 11:14:24 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ua-Compatible:
+      - IE=edge
+      Server:
+      - Apache
+      Set-Cookie:
+      - WSLang-CFC001=EN; expires=Mon, 15-Apr-2069 11:14:23 GMT; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 15 Apr 2019 11:14:24 GMT
+      Content-Length:
+      - '13491'
+    body:
+      encoding: UTF-8
+      string: "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n    \n\n    \n\n<!DOCTYPE html PUBLIC
+        \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\r\n<html
+        lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\r\n<head>\r\n\r\n\t<!--
+        #BeginEditable \"doctitle\" -->\r\n    <title>\r\n    _CARDIFF_PROPLPI_100422_1\r\n
+        \   |\r\n    \r\n\r\n    \r\n\r\n    \r\n\r\n    \r\n    \r\n    \r\n    \r\n
+        \   \r\n        \r\n        47 ELM STREET, ROATH, CARDIFF, CF24 3QS\r\n    \r\n
+        \   \r\n    </title>\r\n<!-- #EndEditable -->\r\n    <!-- #BeginEditable \"metatags\"
+        --><!-- #EndEditable -->\r\n\t\r\n    <meta http-equiv=\"Content-Type\" content=\"text/html;
+        charset=UTF-8\" />\r\n\t\r\n\t<!-- Customer metatags -->\r\n\t\r\n\t\r\n\t<!--
+        Favicon link -->\r\n    <link rel=\"icon\" href=\"/online-applications-skin/images/cardiff/favicon.ico\"
+        type=\"image/x-icon\" />\r\n\t\r\n    <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/screen.css\"
+        type=\"text/css\" media=\"screen,projection\" />\r\n    <link rel=\"stylesheet\"
+        href=\"/online-applications-skin/styles/theme1.css\" type=\"text/css\"/>\t\r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/print.css\"
+        type=\"text/css\" media=\"print\" />   \r\n\r\n    <script type=\"text/javascript\"
+        src=\"/online-applications-skin/scripts/jquery.min.js\"></script>\r\n    <script
+        type=\"text/javascript\" src=\"/online-applications-skin/scripts/jquery.toolbar.idox.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/common.js\"></script>\r\n
+        \       \r\n\t<!-- Customer Analytics Script -->\r\n\t\r\n\t\r\n    <script
+        type=\"text/javascript\">\r\n    \t$('html').addClass('js');\r\n    \t$(document).ready(function(){\r\n
+        \   \t\t$('.main#apply>span:first-child').attr('tabindex', '0')\r\n    \t});\r\n
+        \   </script>\r\n    \r\n    <!-- #BeginEditable \"mobile\" --><!-- #EndEditable
+        -->\r\n    <!-- #BeginEditable \"head\" --><!-- #EndEditable -->\r\n    <!--
+        #BeginEditable \"webapp\" --><!-- #EndEditable -->\r\n\r\n</head>\r\n<body>\r\n\r\n
+        \   <a href=\"#pageheading\" class=\"sr-only\">Skip to main content</a>\r\n\r\n
+        \   <!-- IDOX PA START -->\r\n    <div id=\"idox\">\r\n        <div id=\"pa\">
+        \r\n\t\t\t<div id=\"header\"><!-- Selector: Selector 1 -->\r\n<style>\r\n#langStyle{float:right;
+        margin-top: 10px; margin-right: 30px; background:transparent; font-size:13px;
+        cursor:pointer; border:1px solid #fff !important;border-radius:2px; z-index:999;
+        background-color: #fff; padding:2px;}\r\n#langStyle:hover{text-decoration:
+        underline;}</style>\r\n<div>\r\n\r\n<!--CYS--><a id=\"langStyle\" href=\"/online-applications/propertyDetails.do?previousCaseType=Application&keyVal=_CARDIFF_PROPLPI_100422_1&previousCaseNumber=19%2f00552%2fMNR&activeTab=summary&previousKeyVal=_CARDIFF_DCAPR_126851&lang=CY\">Cymraeg</a><!--CYE-->\r\n</div>\r\n\t\t\t\t<div
+        class=\"container\">\r\n\t\t\t\t\t<div id=\"logo\"><a href=\"https://www.cardiff.gov.uk/\"
+        title=\"Cardiff Council home page\"><img src=\"/online-applications-skin/images/cardiff/logo.png\"
+        alt=\"Council logo\" /><span class=\"sr-only\">Cardiff Council</span></a></div>\r\n\t\t\t\t\t<div
+        id=\"headertitle\"><span></span></div>\r\n\t\t\t\t\t<div class=\"clear\"></div>\r\n\t\t\t\t</div>\t\r\n\t\t\t</div>\r\n\t\t\t<div
+        id=\"breadcrumbs\" class=\"container\">\r\n\t\t\t\t<ul>\r\n\t\t\t\t\t\r\n\t\t\t\t</ul>\r\n\t\t\t</div>\r\n
+        \           <div class=\"container\">\r\n                <div id=\"toolbar\"
+        class=\"nojs\">\r\n                    <ul>\t\r\n                        <li
+        id=\"search\" class=\"main\"><span tabindex=\"0\">Search&nbsp;</span><span
+        class=\"caret\"></span>\r\n   \t\t\t\t\t\t\t<ul>\t\r\n\t\t\t\t\t\t\t\t<!--
+        #BeginLibraryItem \"/Library/searchModulesNavItems.lbi\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \       \r\n            <li id=\"planLinks\">\r\n                <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\"
+        >\r\n                    <span>Planning</span>\r\n                </a>\r\n
+        \               <ul>\r\n                    <li id=\"planBasicSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\">\r\n
+        \                           Simple Search\r\n                        </a>\r\n
+        \                   </li>\r\n\r\n                    <li id=\"planAdvancedSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=advanced&amp;searchType=Application\">\r\n
+        \                           Advanced\r\n                        </a>\r\n                    </li>\r\n
+        \                   <li id=\"planListSearch\">\r\n                        <a
+        href=\"/online-applications/search.do?action=weeklyList&amp;searchType=Application\">\r\n
+        \                           Weekly/Monthly Lists\r\n                        </a>\r\n
+        \                   </li>\r\n                    <li id=\"planPropertySearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=property&amp;type=custom\">\r\n
+        \                           Property Search\r\n                        </a>\r\n
+        \                   </li>\r\n\t\t\t\t\t\r\n                    \r\n\t\t\t\t\t\r\n
+        \               </ul>\r\n            </li>\r\n        \r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        <!-- #EndLibraryItem -->\r\n                        \t</ul>\r\n\t\t\t\t\t\t</li>\r\n
+        \                       <!-- #BeginEditable \"applicationForms\" -->\n\n\n\n\n\n
+        \  \n<!-- #EndEditable -->   \t\t\t\t\r\n                        <li id=\"myprofile\"
+        class=\"main\"><span tabindex=\"0\">My Profile&nbsp;</span><span class=\"caret\"></span>\r\n
+        \                           <ul>\r\n                              <!-- #BeginLibraryItem
+        \"/Library/consulteeInTrayNavItem.lbi\" -->\n\n\n\n\n\n\n    <!-- #EndLibraryItem
+        -->\r\n                                <li><a href=\"/online-applications/registered/displayUserDetails.do\">Profile
+        Details</a></li>\r\n                                <li><a href=\"/online-applications/registered/savedSearch.do?action=display\">Saved
+        Searches</a></li>\r\n                                <li><a href=\"/online-applications/registered/userAdmin.do?action=showNotifiedApplications\">Notified
+        Applications</a></li>\r\n                                <li><a href=\"/online-applications/registered/trackedApplication.do?action=display\">Tracked
+        Applications</a></li>\r\n                                <!-- #BeginEditable
+        \"formSubmissions\" -->\n\n\n\n\n\n\n\n\n<!-- #EndEditable -->    \t\r\n                            </ul>\r\n
+        \                       </li>\r\n                        <li id=\"loginLink\"
+        class=\"main\"><!-- #BeginEditable \"loginlogout\" -->\n\n\n\n\n\n\n\n\n\n\n\t<a
+        href=\"/online-applications/registered/userAdmin.do\">Login</a>\n<!-- #EndEditable
+        --></li>\r\n                        <!-- #BeginEditable \"register\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \  \r\n\r\n\r\n\t<li id=\"register\">\r\n        <a href=\"/online-applications/registrationWizard.do?action=start\">Register</a>\r\n\t</li>\r\n\r\n<!--
+        #EndEditable -->\r\n                        <!-- #BeginLibraryItem \"/Library/applyOnlineNavItems.lbi\"
+        -->\r\n\r\n\r\n\r\n\r\n\r\n<!-- #EndLibraryItem -->\r\n                    </ul>\r\n
+        \   \t\t\t</div>\r\n                \r\n                <div id=\"pageheading\">\r\n
+        \                   <h1><!-- #BeginEditable \"pageheading\" -->Property Address<!--
+        #EndEditable --></h1>\r\n                    <!-- #BeginEditable \"helplink\"
+        -->\r\n<p class=\"pagehelp\">\r\n\t<a title=\"Help with this page (opens in
+        a new window)\" rel=\"external\" target=\"_blank\" href=\"/online-applications/help/pagehelp/properties.htm\">\r\n\t\tHelp
+        with this page\r\n\t<span> (opens in a new window)</span>\r\n\t</a>\r\n</p>\r\n<!--
+        #EndEditable -->\r\n                </div>\r\n        \r\n                <!--
+        START WAM CONTENT -->\r\n                <div class=\"content\">\r\n                    <!--
+        #BeginEditable \"errormsg\" -->\n        \n        \n\n        \n        \n
+        \   <!-- #EndEditable -->\r\n                    <!-- #BeginEditable \"pagehead\"
+        -->\r\n\r\n    <div class=\"addressCrumb\">\r\n        <span class=\"caseNumber\">\r\n
+        \           \r\n                100100058644 \r\n            \r\n\r\n            \r\n
+        \       </span>\r\n\r\n        <span class=\"divider1\">|</span>\r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        \r\n\r\n        \r\n        \r\n        \r\n        \r\n
+        \       \r\n            \r\n            <span class=\"address\">\r\n                47
+        ELM STREET, ROATH, CARDIFF, CF24 3QS\r\n            </span>\r\n        \r\n
+        \       \r\n    </div>\r\n\r\n\r\n    <div id=\"applicationTools\">\r\n        <ul>\r\n
+        \           \r\n            \r\n\r\n            \r\n\r\n            \r\n            \r\n
+        \               <li>\r\n                    <a href=\"/online-applications/applicationDetails.do?keyVal=_CARDIFF_DCAPR_126851&amp;activeTab=summary\"
+        id=\"searchresultsback\">\r\n                        Planning Application\r\n
+        \                       \r\n                        \r\n                            19/00552/MNR\r\n
+        \                       \r\n                    </a>\r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n            \r\n            \r\n\r\n\r\n
+        \           \r\n                \r\n             \r\n            \r\n\r\n
+        \           \r\n            \r\n                \r\n            \r\n            \r\n
+        \           \r\n            <li>\r\n                <a href=\"/online-applications/propertyDetails.do?activeTab=printPreview&amp;keyVal=_CARDIFF_PROPLPI_100422_1\"
+        id=\"print\" rel=\"external\">\r\n                    <img src=\"/online-applications-skin/images/button_print.gif\"
+        alt=\"Print summary icon\" width=\"53\" height=\"22\" border=\"0\"/>\r\n                </a>\r\n
+        \           </li>\r\n            \r\n\r\n            \r\n        </ul>\r\n\r\n
+        \   </div>\r\n\r\n\r\n     \r\n\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabs\" -->\r\n    \r\n    <ul class=\"tabs\">\r\n\r\n        \r\n\r\n
+        \           \r\n                \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/propertyDetails.do?activeTab=summary&amp;keyVal=_CARDIFF_PROPLPI_100422_1\"
+        id=\"tab_summary\" class=\"active\">\r\n                        <span>\r\n
+        \                           Address\r\n                            \r\n                        </span>\r\n
+        \                   </a>\r\n\r\n                    \r\n                    \r\n
+        \                   \r\n                        \r\n                        \r\n
+        \                   \r\n                </li>\r\n            \r\n\r\n            \r\n\r\n
+        \       \r\n\r\n            \r\n                \r\n                <li>\r\n\r\n
+        \                    \r\n                    <a href=\"/online-applications/propertyDetails.do?activeTab=relatedCases&amp;keyVal=_CARDIFF_PROPLPI_100422_1\"
+        id=\"tab_relatedCases\">\r\n                        <span>\r\n                            Property
+        History\r\n                            \r\n                                \r\n
+        \                               (3)\r\n                            \r\n                        </span>\r\n
+        \                   </a>\r\n\r\n                    \r\n                    \r\n
+        \                   \r\n                </li>\r\n            \r\n\r\n            \r\n\r\n
+        \       \r\n\r\n            \r\n                \r\n                <li>\r\n\r\n
+        \                    \r\n                    <a href=\"/online-applications/propertyDetails.do?activeTab=constraints&amp;keyVal=_CARDIFF_PROPLPI_100422_1\"
+        id=\"tab_constraints\">\r\n                        <span>\r\n                            Constraints\r\n
+        \                           \r\n                                \r\n                                (1)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n\r\n
+        \           \r\n\r\n        \r\n    </ul>\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabsubnav\" --><!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"pagebody\" -->\n    \r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\n
+        \   \n        \n        \n    \n\n    \n    \n    \n    \n    \n        \n
+        \       \n    \n\n    <div class=\"tabcontainer toplevel\">\n\n        \n
+        \       \n        \n            \n            <table id=\"propertyAddress\"
+        summary=\"Property address\">\r\n<tr class=\"row0\">\r\n<th scope=\"row\">UPRN:</th>\r\n<td>100100058644</td>\r\n</tr>\r\n<tr
+        class=\"row1\">\r\n<th scope=\"row\">Full Address:</th>\r\n<td>47 ELM STREET,
+        ROATH, CARDIFF, CF24 3QS</td>\r\n</tr>\r\n<tr class=\"row1\">\r\n<th scope=\"row\">Property
+        Number:</th>\r\n<td>47</td>\r\n</tr>\r\n<tr class=\"row0\">\r\n<th scope=\"row\">Street:</th>\r\n<td>ELM
+        STREET</td>\r\n</tr>\r\n<tr class=\"row1\">\r\n<th scope=\"row\">Town:</th>\r\n<td>CARDIFF</td>\r\n</tr>\r\n<tr
+        class=\"row0\">\r\n<th scope=\"row\">Postcode:</th>\r\n<td>CF24 3QS</td>\r\n</tr>\r\n<tr
+        class=\"row1\">\r\n<th scope=\"row\">Ward:</th>\r\n<td>PLASNEWYDD</td>\r\n</tr>\r\n<tr
+        class=\"row0\">\r\n<th scope=\"row\">Parish:</th>\r\n<td/>\r\n</tr>\r\n</table>\r\n\n
+        \       \n\n        \n        \n\n        \n        \n            \n        \n\n
+        \   </div>\n<!-- #EndEditable -->\r\n                    <!-- #BeginEditable
+        \"pagefoot\" --><!-- #EndEditable -->\r\n                </div>\r\n                <!--
+        END WAM CONTENT -->\r\n                \r\n                <p id=\"poweredBy\"><a
+        href=\"http://www.idoxgroup.com/\" target=\"_blank\" title=\"This link will
+        open a new window\"><img src=\"/online-applications-skin/images/idox.gif\"
+        alt=\"an Idox solution\" /></a></p>\r\n            </div>\r\n\t\t\t<div id=\"footer\">\r\n\t\t\t\t<div
+        class=\"container\">\t\t\t\t\t\r\n\t\t\t\t\t<div id=\"links\">\r\n\t\t\t\t\t\t<ul>\r\n\t\t\t\t\t\t\t<li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/Site_Map/Pages/default.aspx\">Site
+        map</a></li><li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Cookies/Pages/Cookies.aspx\">Cookies</a></li><li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/New_Disclaimer/Pages/default.aspx\">Disclaimer</a></li>\r\n\t\t\t\t\t\t</ul>\r\n\t\t\t\t\t</div>\r\n\t\t\t\t\t<div
+        class=\"clear\"></div>\r\n\t\t\t\t</div>\r\n\t\t\t</div>\r\n\t\t\t<div id=\"footerBottom\">\r\n\t\t\t
+        \   <div class=\"container\">\r\n\t\t\t        <div id=\"footercontent\"><p>&copy;
+        <script type=\"text/javascript\">document.write(new Date().getFullYear());</script>
+        Cardiff Council</p></div>\r\n\t\t\t        <div class=\"clear\"></div>\r\n\t\t\t
+        \   </div>\r\n\t\t\t</div>\r\n        </div>\r\n    </div>\r\n    <!-- IDOX
+        PA END -->\r\n\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Mon, 15 Apr 2019 11:13:53 GMT
+- request:
+    method: get
+    uri: https://planningonline.cardiff.gov.uk/online-applications/applicationDetails.do?activeTab=summary&keyVal=_CARDIFF_DCAPR_126784
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip,deflate,identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mechanize/2.7.6 Ruby/2.6.2p47 (http://github.com/sparklemotion/mechanize/)
+      Accept-Charset:
+      - ISO-8859-1,utf-8;q=0.7,*;q=0.7
+      Accept-Language:
+      - en-us,en;q=0.5
+      Cookie:
+      - JSESSIONID=ss9pKoHL32yHmhJQONSykek96zXCSSZ75skxJ5v1.vmidoxweblve; WSLang-CFC001=EN
+      Host:
+      - planningonline.cardiff.gov.uk
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '300'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - text/html; charset=UTF-8
+      Expires:
+      - Mon, 15 Apr 2019 11:14:39 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ua-Compatible:
+      - IE=edge
+      Server:
+      - Apache
+      Set-Cookie:
+      - WSLang-CFC001=EN; expires=Mon, 15-Apr-2069 11:14:35 GMT; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 15 Apr 2019 11:14:39 GMT
+      Content-Length:
+      - '28283'
+    body:
+      encoding: UTF-8
+      string: "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n    \n\n    \n\n<!DOCTYPE html PUBLIC
+        \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\r\n<html
+        lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\r\n<head>\r\n\t\r\n\t<!--
+        #BeginEditable \"doctitle\" -->\r\n    <title>\r\n    19/00503/DCH\r\n    |\r\n
+        \   \r\n        SINGLE STOREY REAR EXTENSION WITH PITCH ROOF\r\n        \r\n
+        \       |\r\n        \r\n    \r\n\r\n    \r\n\r\n    \r\n\r\n    \r\n    \r\n
+        \   \r\n    \r\n    \r\n        \r\n        81 KYLE CRESCENT, WHITCHURCH,
+        CARDIFF, CF14 1SU\r\n    \r\n    \r\n    </title>\r\n<!-- #EndEditable -->\r\n
+        \   <!-- #BeginEditable \"metatags\" --><!-- #EndEditable -->\r\n\t\r\n    <meta
+        http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" />\r\n\t\r\n\t<!--
+        Customer metatags -->\r\n\t\r\n\t\r\n\t<!-- Favicon link -->\r\n    <link
+        rel=\"icon\" href=\"/online-applications-skin/images/cardiff/favicon.ico\"
+        type=\"image/x-icon\" />\r\n\t\r\n    <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/screen.css\"
+        type=\"text/css\" media=\"screen,projection\" />\r\n    <link rel=\"stylesheet\"
+        href=\"/online-applications-skin/styles/theme1.css\" type=\"text/css\"/>    \r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/print.css\"
+        type=\"text/css\" media=\"print\" />\r\n\t\r\n    <script type=\"text/javascript\"
+        src=\"/online-applications-skin/scripts/jquery.min.js\"></script>\r\n    <script
+        type=\"text/javascript\" src=\"/online-applications-skin/scripts/jquery.toolbar.idox.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/common.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/checkbox.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/amplify.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/createCommentCookie.js\"></script>\r\n
+        \       \r\n\t<!-- Customer Analytics Script -->\r\n\t\r\n\t\r\n    <script
+        type=\"text/javascript\">\r\n    \t$('html').addClass('js');\r\n    \t$(document).ready(function(){\r\n
+        \   \t\t$('.main#apply>span:first-child').attr('tabindex', '0')\r\n    \t});\r\n
+        \   </script>\r\n    \r\n    <!-- #BeginEditable \"mobile\" --><!-- #EndEditable
+        -->\r\n    <!-- #BeginEditable \"head\" -->\r\n\t<script type=\"text/javascript\">\r\n\t
+        \   jQuery(document).ready(function() {\t\r\n\t\t\tjQuery('#pa').before('<img
+        src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\" id=\"preload\"
+        />');\r\n\t\t\tjQuery('#preload').hide();\r\n\t\t\tjQuery('.tabs a#tab_documents').click(
+        function(event) {\r\n\t\t\t\t  window.clearTimeout(window.timeOutId);\r\n\t\t\t\t
+        \ window.timeOutId = window.setTimeout(function() {\r\n\t\t\t\t\t\tjQuery('.content').before('<div
+        id=\"overlay\"></div><div id=\"loading\"><div id=\"message\">Loading. Please
+        wait.... <img src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\"
+        height=\"19\" width=\"220\" style=\"background:#fff;\" /></div></div>');\r\n\t\t\t\t
+        \ },10);\r\n\t\t\t\t});\r\n\t\t\tjQuery('p.associateddocument a').click( function(event)
+        {\r\n\t\t\t\t  window.clearTimeout(window.timeOutId);\r\n\t\t\t\t  window.timeOutId
+        = window.setTimeout(function() {\r\n\t\t\t\t\t\tjQuery('.content').before('<div
+        id=\"overlay\"></div><div id=\"loading\"><div id=\"message\">Loading. Please
+        wait.... <img src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\"
+        height=\"19\" width=\"220\" style=\"background:#fff;\" /></div></div>');\r\n\t\t\t\t
+        \ },10);\r\n\t\t\t\t});\r\n\r\n\t\t});\r\n    </script>\r\n    \r\n    <link
+        rel=\"stylesheet\" href=\"/online-applications-skin/styles/simple_social_share.min.css\"
+        type=\"text/css\"/>\r\n    <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/simple_social_share.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\">\r\n        $(document).ready(function(){\r\n
+        \           \r\n            \r\n            $(\"share-button\").simpleSocialShare({\r\n
+        \               sites: \"twitter,email\", \r\n                url: window.location.href,
+        \r\n                title: \"Online application\", \r\n                description:
+        \"Please look at this Planning Application: \", \r\n                shareType:
+        \"button\", \r\n                buttonSide: \"left\", \r\n                orientation:
+        \"horizontal\"\r\n            });\r\n        });\r\n\t</script>\r\n\t<!--
+        #EndEditable -->\r\n    <!-- #BeginEditable \"webapp\" --><!-- #EndEditable
+        -->\r\n\r\n</head>\r\n<body>\r\n\r\n    <a href=\"#pageheading\" class=\"sr-only\">Skip
+        to main content</a>\r\n\r\n    <!-- IDOX PA START -->\r\n    <div id=\"idox\">\r\n
+        \       <div id=\"pa\">\r\n\t\t\t<div id=\"header\"><!-- Selector: Selector
+        1 -->\r\n<style>\r\n#langStyle{float:right; margin-top: 10px; margin-right:
+        30px; background:transparent; font-size:13px; cursor:pointer; border:1px solid
+        #fff !important;border-radius:2px; z-index:999; background-color: #fff; padding:2px;}\r\n#langStyle:hover{text-decoration:
+        underline;}</style>\r\n<div>\r\n\r\n<!--CYS--><a id=\"langStyle\" href=\"/online-applications/applicationDetails.do?keyVal=_CARDIFF_DCAPR_126784&activeTab=summary&lang=CY\">Cymraeg</a><!--CYE-->\r\n</div>\r\n\t\t\t\t<div
+        class=\"container\">\r\n\t\t\t\t\t<div id=\"logo\"><a href=\"https://www.cardiff.gov.uk/\"
+        title=\"Cardiff Council home page\"><img src=\"/online-applications-skin/images/cardiff/logo.png\"
+        alt=\"Council logo\" /><span class=\"sr-only\">Cardiff Council</span></a></div>\r\n\t\t\t\t\t<div
+        id=\"headertitle\"><span></span></div>\r\n\t\t\t\t\t<div class=\"clear\"></div>\r\n\t\t\t\t</div>\t\r\n\t\t\t</div>\r\n\t\t\t<div
+        id=\"breadcrumbs\" class=\"container\">\r\n\t\t\t\t<ul>\r\n\t\t\t\t\t\r\n\t\t\t\t</ul>\r\n\t\t\t</div>\r\n
+        \           <div class=\"container\">\r\n       \t\t\t<div id=\"toolbar\"
+        class=\"nojs\">\r\n                    <ul>\t\r\n                        <li
+        id=\"search\" class=\"main\"><span tabindex=\"0\">Search&nbsp;</span><span
+        class=\"caret\"></span>\r\n   \t\t\t\t\t\t\t<ul>\t\r\n\t\t\t\t\t\t\t\t<!--
+        #BeginLibraryItem \"/Library/searchModulesNavItems.lbi\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \       \r\n            <li id=\"planLinks\">\r\n                <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\"
+        >\r\n                    <span>Planning</span>\r\n                </a>\r\n
+        \               <ul>\r\n                    <li id=\"planBasicSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\">\r\n
+        \                           Simple Search\r\n                        </a>\r\n
+        \                   </li>\r\n\r\n                    <li id=\"planAdvancedSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=advanced&amp;searchType=Application\">\r\n
+        \                           Advanced\r\n                        </a>\r\n                    </li>\r\n
+        \                   <li id=\"planListSearch\">\r\n                        <a
+        href=\"/online-applications/search.do?action=weeklyList&amp;searchType=Application\">\r\n
+        \                           Weekly/Monthly Lists\r\n                        </a>\r\n
+        \                   </li>\r\n                    <li id=\"planPropertySearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=property&amp;type=custom\">\r\n
+        \                           Property Search\r\n                        </a>\r\n
+        \                   </li>\r\n\t\t\t\t\t\r\n                    \r\n\t\t\t\t\t\r\n
+        \               </ul>\r\n            </li>\r\n        \r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        <!-- #EndLibraryItem -->\r\n                        \t</ul>\r\n\t\t\t\t\t\t</li>\r\n
+        \                       <!-- #BeginEditable \"applicationForms\" -->\n\n\n\n\n\n
+        \  \n<!-- #EndEditable -->   \t\t\t\t\r\n                        <li id=\"myprofile\"
+        class=\"main\"><span tabindex=\"0\">My Profile&nbsp;</span><span class=\"caret\"></span>\r\n
+        \                           <ul>\r\n                              <!-- #BeginLibraryItem
+        \"/Library/consulteeInTrayNavItem.lbi\" -->\n\n\n\n\n\n\n    <!-- #EndLibraryItem
+        -->\r\n                                <li><a href=\"/online-applications/registered/displayUserDetails.do\">Profile
+        Details</a></li>\r\n                                <li><a href=\"/online-applications/registered/savedSearch.do?action=display\">Saved
+        Searches</a></li>\r\n                                <li><a href=\"/online-applications/registered/userAdmin.do?action=showNotifiedApplications\">Notified
+        Applications</a></li>\r\n                                <li><a href=\"/online-applications/registered/trackedApplication.do?action=display\">Tracked
+        Applications</a></li>\r\n                                <!-- #BeginEditable
+        \"formSubmissions\" -->\n\n\n\n\n\n\n\n\n<!-- #EndEditable -->    \t\r\n                            </ul>\r\n
+        \                       </li>\r\n                        <li id=\"loginLink\"
+        class=\"main\"><!-- #BeginEditable \"loginlogout\" -->\n\n\n\n\n\n\n\n\n\n\n\t<a
+        href=\"/online-applications/registered/userAdmin.do\">Login</a>\n<!-- #EndEditable
+        --></li>\r\n                        <!-- #BeginEditable \"register\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \  \r\n\r\n\r\n\t<li id=\"register\">\r\n        <a href=\"/online-applications/registrationWizard.do?action=start\">Register</a>\r\n\t</li>\r\n\r\n<!--
+        #EndEditable -->\r\n                        <!-- #BeginLibraryItem \"/Library/applyOnlineNavItems.lbi\"
+        -->\r\n\r\n\r\n\r\n\r\n\r\n<!-- #EndLibraryItem -->\r\n                    </ul>\r\n
+        \   \t\t\t</div>\r\n\r\n    \t\t\t<!-- #BeginEditable \"headlinenews\" --><!--
+        #EndEditable -->\r\n                 \r\n                <div id=\"pageheading\">\r\n
+        \                   <h1><strong>Planning</strong>&nbsp;&ndash;&nbsp;<!-- #BeginEditable
+        \"pageheading\" -->Application Summary<!-- #EndEditable --></h1>\r\n                    <!--
+        #BeginEditable \"helplink\" -->\r\n<p class=\"pagehelp\">\r\n\t<a title=\"Help
+        with this page (opens in a new window)\" rel=\"external\" target=\"_blank\"
+        href=\"/online-applications/help/pagehelp/applications.htm\">\r\n\t\tHelp
+        with this page\r\n\t<span> (opens in a new window)</span>\r\n\t</a>\r\n</p>\r\n<!--
+        #EndEditable -->\r\n                </div>\r\n                \r\n                <!--
+        START WAM CONTENT -->\r\n                <div class=\"content\">\r\n                    <!--
+        #BeginEditable \"errormsg\" -->\n        \n        \n\n        \n        \n
+        \   <!-- #EndEditable -->\r\n                    <!-- #BeginEditable \"pagehead\"
+        -->\r\n\r\n    <div class=\"addressCrumb\">\r\n        <span class=\"caseNumber\">\r\n
+        \           \r\n\r\n            \r\n                19/00503/DCH\r\n            \r\n
+        \       </span>\r\n\r\n        <span class=\"divider1\">|</span>\r\n\r\n        \r\n
+        \           <span class=\"description\">\r\n                SINGLE STOREY
+        REAR EXTENSION WITH PITCH ROOF\r\n            </span>\r\n            \r\n
+        \               <span class=\"divider2\">|</span>\r\n            \r\n        \r\n\r\n
+        \       \r\n\r\n        \r\n\r\n        \r\n        \r\n        \r\n        \r\n
+        \       \r\n            \r\n            <span class=\"address\">\r\n                81
+        KYLE CRESCENT, WHITCHURCH, CARDIFF, CF14 1SU\r\n            </span>\r\n        \r\n
+        \       \r\n    </div>\r\n\r\n\r\n    <div id=\"applicationTools\">\r\n        <ul>\r\n
+        \           \r\n            \r\n                \r\n                    \r\n
+        \                       \r\n                            \r\n                            \r\n
+        \                               \r\n                                    <li>\r\n
+        \                                       <a href=\"/online-applications/searchResultsBack.do?action=back\"
+        id=\"searchresultsback\">Back to search results</a>\r\n                                    </li>\r\n
+        \                               \r\n                            \r\n                        \r\n
+        \                   \r\n                    \r\n                    \r\n                \r\n
+        \           \r\n\r\n            \r\n\r\n            \r\n            \r\n\r\n
+        \           \r\n\r\n            \r\n            \r\n                \r\n                    <li>\r\n
+        \                       <form name=\"trackForm\" method=\"post\" action=\"/online-applications/registered/trackedApplicationSubmit.do?action=track\"><input
+        type=\"hidden\" name=\"org.apache.struts.taglib.html.TOKEN\" value=\"29bf2f123dcac4b68758826c788ef8f0\"
+        />\r\n                            <input type=\"hidden\" name=\"caseNo\" value=\"19/00503/DCH\"
+        />\r\n                            <input type=\"hidden\" name=\"caseType\"
+        value=\"Application\" />\r\n                            <input type=\"hidden\"
+        name=\"address\" value=\"81 KYLE CRESCENT, WHITCHURCH, CARDIFF, CF14 1SU\"
+        />\r\n                            <input type=\"hidden\" name=\"description\"
+        value=\"SINGLE STOREY REAR EXTENSION WITH PITCH ROOF\" />\r\n                            <input
+        type=\"hidden\" name=\"status\" value=\"Decided\" />\r\n                            <input
+        type=\"hidden\" name=\"trackingStatus\" value=\"Decided\" />\r\n                            <input
+        type=\"hidden\" name=\"caseTechnicalKey\" value=\"_CARDIFF_DCAPR_126784\"
+        />\r\n                            <input class=\"casefiletrack\"\r\n                                   src=\"/online-applications-skin/images/button_track.gif\"\r\n
+        \                                  type=\"image\"\r\n                                   name=\"submit\"\r\n
+        \                                  altKey=\"casedetails.track\"\r\n                                   title=\"Get
+        informed when this item is updated\"/>\r\n                        </form>\r\n
+        \                   </li>\r\n                \r\n\r\n                \r\n
+        \           \r\n\r\n\r\n            \r\n                \r\n             \r\n
+        \           \r\n\r\n            \r\n            \r\n                \r\n            \r\n
+        \           \r\n            \r\n            <li>\r\n                <a href=\"/online-applications/applicationDetails.do?activeTab=printPreview&amp;keyVal=_CARDIFF_DCAPR_126784\"
+        id=\"print\" rel=\"external\">\r\n                    <img src=\"/online-applications-skin/images/button_print.gif\"
+        alt=\"Print summary icon\" width=\"53\" height=\"22\" border=\"0\"/>\r\n                </a>\r\n
+        \           </li>\r\n            \r\n\r\n            \r\n        </ul>\r\n\r\n
+        \   </div>\r\n\r\n\r\n     \r\n\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabs\" -->\r\n    \r\n    <ul class=\"tabs\">\r\n\r\n        \r\n\r\n
+        \           \r\n                \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/applicationDetails.do?activeTab=summary&amp;keyVal=_CARDIFF_DCAPR_126784\"
+        id=\"tab_summary\" class=\"active\">\r\n                        <span>\r\n
+        \                           Details\r\n                            \r\n                        </span>\r\n
+        \                   </a>\r\n\r\n                    \r\n                    \r\n
+        \                   \r\n                        \r\n                        \r\n\r\n
+        \                           <ul class=\"subtabs\">\r\n                                \r\n
+        \                                   \r\n                                        <li>\r\n
+        \                                           \r\n                                            <a
+        href=\"/online-applications/applicationDetails.do?activeTab=summary&amp;keyVal=_CARDIFF_DCAPR_126784\"
+        id=\"subtab_summary\" class=\"active\">\r\n                                                <span>\r\n
+        \                                                   Summary\r\n                                                    \r\n
+        \                                               </span>\r\n                                            </a>\r\n
+        \                                       </li>\r\n                                    \r\n
+        \                               \r\n                                    \r\n
+        \                                       <li>\r\n                                            \r\n
+        \                                           <a href=\"/online-applications/applicationDetails.do?activeTab=details&amp;keyVal=_CARDIFF_DCAPR_126784\"
+        id=\"subtab_details\">\r\n                                                <span>\r\n
+        \                                                   Further Information\r\n
+        \                                                   \r\n                                                </span>\r\n
+        \                                           </a>\r\n                                        </li>\r\n
+        \                                   \r\n                                \r\n
+        \                                   \r\n                                        <li>\r\n
+        \                                           \r\n                                            <a
+        href=\"/online-applications/applicationDetails.do?activeTab=contacts&amp;keyVal=_CARDIFF_DCAPR_126784\"
+        id=\"subtab_contacts\">\r\n                                                <span>\r\n
+        \                                                   Contacts\r\n                                                    \r\n
+        \                                               </span>\r\n                                            </a>\r\n
+        \                                       </li>\r\n                                    \r\n
+        \                               \r\n                                    \r\n
+        \                                       <li>\r\n                                            \r\n
+        \                                           <a href=\"/online-applications/applicationDetails.do?activeTab=dates&amp;keyVal=_CARDIFF_DCAPR_126784\"
+        id=\"subtab_dates\">\r\n                                                <span>\r\n
+        \                                                   Important Dates\r\n                                                    \r\n
+        \                                               </span>\r\n                                            </a>\r\n
+        \                                       </li>\r\n                                    \r\n
+        \                               \r\n                            </ul>\r\n\r\n
+        \                       \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n                \r\n
+        \               <li>\r\n\r\n                     \r\n                    <a
+        href=\"/online-applications/applicationDetails.do?activeTab=makeComment&amp;keyVal=_CARDIFF_DCAPR_126784\"
+        id=\"tab_makeComment\">\r\n                        <span>\r\n                            Comments\r\n
+        \                           \r\n                                \r\n                                (0)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n\r\n
+        \           \r\n                <li class=\"nodocuments\">\r\n                    <span>\r\n
+        \                       Constraints\r\n                        \r\n                            \r\n
+        \                           (0)\r\n                        \r\n                    </span>\r\n
+        \               </li>\r\n            \r\n\r\n        \r\n\r\n            \r\n
+        \               \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/applicationDetails.do?activeTab=documents&amp;keyVal=_CARDIFF_DCAPR_126784\"
+        id=\"tab_documents\">\r\n                        <span>\r\n                            Documents\r\n
+        \                           \r\n                                \r\n                                (6)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n                \r\n
+        \               <li>\r\n\r\n                     \r\n                    <a
+        href=\"/online-applications/applicationDetails.do?activeTab=relatedCases&amp;keyVal=_CARDIFF_DCAPR_126784\"
+        id=\"tab_relatedCases\">\r\n                        <span>\r\n                            Related
+        Cases\r\n                            \r\n                                \r\n
+        \                               (1)\r\n                            \r\n                        </span>\r\n
+        \                   </a>\r\n\r\n                    \r\n                    \r\n
+        \                   \r\n                </li>\r\n            \r\n\r\n            \r\n\r\n
+        \       \r\n\r\n            \r\n\r\n            \r\n\r\n        \r\n    </ul>\r\n<!--
+        #EndEditable -->\r\n                    <!-- #BeginEditable \"tabsubnav\"
+        --><!-- #EndEditable -->\r\n                    <!-- #BeginEditable \"pagebody\"
+        -->\n    \r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\n
+        \   \n        \n        \n    \n\n    \n    \n    \n    \n    \n\n    <div
+        class=\"tabcontainer\">\n\n        \n        \n        \n\n        \n        \n\n
+        \           \n            \n                \n            \n\n            \n
+        \               <table id=\"simpleDetailsTable\" summary=\"Case Details\">\n\n
+        \                   \n                    \n                        \n                            <tr>\n
+        \                               <th scope=\"row\" width=\"40%\">\n                                    Reference\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            19/00503/DCH\n
+        \                                       \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Alternative Reference\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            PP-07678469\n
+        \                                       \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Application Received\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            Tue
+        05 Mar 2019\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Application Validated\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            Thu
+        07 Mar 2019\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Address\n                                </th>\n
+        \                               <td>\n                                    \n
+        \                                       \n                                        \n
+        \                                           81 KYLE CRESCENT, WHITCHURCH,
+        CARDIFF, CF14 1SU\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Proposal\n                                </th>\n
+        \                               <td>\n                                    \n
+        \                                       \n                                        \n
+        \                                           SINGLE STOREY REAR EXTENSION WITH
+        PITCH ROOF\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Status\n                                </th>\n
+        \                               <td>\n                                    \n
+        \                                       \n                                            <span
+        class=\"caseDetailsStatus\">Decided</span>\n                                        \n
+        \                                       \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Decision\n                                </th>\n
+        \                               <td>\n                                    \n
+        \                                       \n                                        \n
+        \                                           Permission be granted\n                                        \n
+        \                                   \n                                </td>\n
+        \                           </tr>\n                        \n                    \n
+        \                       \n                            <tr>\n                                <th
+        scope=\"row\" width=\"40%\">\n                                    Decision
+        Issued Date\n                                </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            Mon
+        08 Apr 2019\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Appeal Decision\n                                </th>\n
+        \                               <td>\n                                    \n
+        \                                       \n                                        \n
+        \                                           \n                                        \n
+        \                                   \n                                </td>\n
+        \                           </tr>\n                        \n                    \n\n
+        \               </table>\n\n                \n                \n\n                \n\n
+        \           \n\n            \n\n        \n\n        \n        \n            \n
+        \               <div id=\"summaryInfo\">\n                    \n                    \n
+        \                   \n                        \n                            \n
+        \                       \n                    \n\n                    \n                    \n
+        \                       <p class=\"associateddocument\">There are <a href=\"/online-applications/applicationDetails.do?activeTab=documents&amp;keyVal=_CARDIFF_DCAPR_126784\">6
+        documents</a> associated with this application.</p><p class=\"associatedcase\">There
+        are 0 cases associated with this application.</p><p class=\"associatedproperty\">There
+        is <a href=\"/online-applications/applicationDetails.do?activeTab=relatedCases&amp;keyVal=_CARDIFF_DCAPR_126784\">1
+        property</a> associated with this application.</p>\r\n\n                    \n
+        \               </div>\n            \n        \n\n    </div>\n<!-- #EndEditable
+        -->\r\n                    <!-- #BeginEditable \"pagefoot\" --><!-- #EndEditable
+        -->\r\n                </div>\r\n                <!-- END WAM CONTENT -->\r\n
+        \               \r\n                <p id=\"poweredBy\"><a href=\"http://www.idoxgroup.com/\"
+        target=\"_blank\" title=\"This link will open a new window\"><img src=\"/online-applications-skin/images/idox.gif\"
+        alt=\"an Idox solution\" /></a></p>\r\n            </div>\t\r\n\t\t\t<div
+        id=\"footer\">\r\n\t\t\t\t<div class=\"container\">\t\t\t\t\t\r\n\t\t\t\t\t<div
+        id=\"links\">\r\n\t\t\t\t\t\t<ul>\r\n\t\t\t\t\t\t\t<li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Site_Map/Pages/default.aspx\">Site
+        map</a></li><li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Cookies/Pages/Cookies.aspx\">Cookies</a></li><li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/New_Disclaimer/Pages/default.aspx\">Disclaimer</a></li>\r\n\t\t\t\t\t\t</ul>\r\n\t\t\t\t\t</div>\r\n\t\t\t\t\t<div
+        class=\"clear\"></div>\r\n\t\t\t\t</div>\r\n\t\t\t</div>\r\n\t\t\t<div id=\"footerBottom\">\r\n\t\t\t
+        \   <div class=\"container\">\r\n\t\t\t        <div id=\"footercontent\"><p>&copy;
+        <script type=\"text/javascript\">document.write(new Date().getFullYear());</script>
+        Cardiff Council</p></div>\r\n\t\t\t        <div class=\"clear\"></div>\r\n\t\t\t
+        \   </div>\r\n\t\t\t</div>\r\n        </div>    \r\n    </div>  \r\n    <!--
+        IDOX PA END -->           \r\n\t\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Mon, 15 Apr 2019 11:14:07 GMT
+- request:
+    method: get
+    uri: https://planningonline.cardiff.gov.uk/online-applications/applicationDetails.do?activeTab=relatedCases&keyVal=_CARDIFF_DCAPR_126784
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip,deflate,identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mechanize/2.7.6 Ruby/2.6.2p47 (http://github.com/sparklemotion/mechanize/)
+      Accept-Charset:
+      - ISO-8859-1,utf-8;q=0.7,*;q=0.7
+      Accept-Language:
+      - en-us,en;q=0.5
+      Cookie:
+      - JSESSIONID=ss9pKoHL32yHmhJQONSykek96zXCSSZ75skxJ5v1.vmidoxweblve; WSLang-CFC001=EN
+      Host:
+      - planningonline.cardiff.gov.uk
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '300'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - text/html; charset=UTF-8
+      Expires:
+      - Mon, 15 Apr 2019 11:14:40 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ua-Compatible:
+      - IE=edge
+      Server:
+      - Apache
+      Set-Cookie:
+      - WSLang-CFC001=EN; expires=Mon, 15-Apr-2069 11:14:39 GMT; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 15 Apr 2019 11:14:40 GMT
+      Content-Length:
+      - '19901'
+    body:
+      encoding: UTF-8
+      string: "\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n<!DOCTYPE
+        html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\r\n<html
+        lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\r\n<head>\r\n\t\r\n\t<!--
+        #BeginEditable \"doctitle\" -->\r\n    <title>\r\n    19/00503/DCH\r\n    |\r\n
+        \   \r\n        SINGLE STOREY REAR EXTENSION WITH PITCH ROOF\r\n        \r\n
+        \       |\r\n        \r\n    \r\n\r\n    \r\n\r\n    \r\n\r\n    \r\n    \r\n
+        \   \r\n    \r\n    \r\n        \r\n        81 KYLE CRESCENT, WHITCHURCH,
+        CARDIFF, CF14 1SU\r\n    \r\n    \r\n    </title>\r\n<!-- #EndEditable -->\r\n
+        \   <!-- #BeginEditable \"metatags\" --><!-- #EndEditable -->\r\n\t\r\n    <meta
+        http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" />\r\n\t\r\n\t<!--
+        Customer metatags -->\r\n\t\r\n\t\r\n\t<!-- Favicon link -->\r\n    <link
+        rel=\"icon\" href=\"/online-applications-skin/images/cardiff/favicon.ico\"
+        type=\"image/x-icon\" />\r\n\t\r\n    <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/screen.css\"
+        type=\"text/css\" media=\"screen,projection\" />\r\n    <link rel=\"stylesheet\"
+        href=\"/online-applications-skin/styles/theme1.css\" type=\"text/css\"/>    \r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/print.css\"
+        type=\"text/css\" media=\"print\" />\r\n\t\r\n    <script type=\"text/javascript\"
+        src=\"/online-applications-skin/scripts/jquery.min.js\"></script>\r\n    <script
+        type=\"text/javascript\" src=\"/online-applications-skin/scripts/jquery.toolbar.idox.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/common.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/checkbox.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/amplify.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/createCommentCookie.js\"></script>\r\n
+        \       \r\n\t<!-- Customer Analytics Script -->\r\n\t\r\n\t\r\n    <script
+        type=\"text/javascript\">\r\n    \t$('html').addClass('js');\r\n    \t$(document).ready(function(){\r\n
+        \   \t\t$('.main#apply>span:first-child').attr('tabindex', '0')\r\n    \t});\r\n
+        \   </script>\r\n    \r\n    <!-- #BeginEditable \"mobile\" --><!-- #EndEditable
+        -->\r\n    <!-- #BeginEditable \"head\" --><!-- #EndEditable -->\r\n    <!--
+        #BeginEditable \"webapp\" -->\r\n\t<script type=\"text/javascript\">\r\n\t
+        \   jQuery(document).ready(function() {\t\t\r\n\t\t\tjQuery('#pa').before('<img
+        src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\" id=\"preload\"
+        />');\r\n\t\t\tjQuery('#preload').hide();\r\n\t\t\tjQuery('.tabs a#tab_documents').click(
+        function(event) {\r\n\t\t\t\t  window.clearTimeout(window.timeOutId);\r\n\t\t\t\t
+        \ window.timeOutId = window.setTimeout(function() {\r\n\t\t\t\t\t\tjQuery('.content').before('<div
+        id=\"overlay\"></div><div id=\"loading\"><div id=\"message\">Loading. Please
+        wait.... <img src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\"
+        height=\"19\" width=\"220\" style=\"background:#fff;\" /></div></div>');\r\n\t\t\t\t
+        \ },10); \r\n\t\t\t\t});\r\n\t\t\t\t\r\n\t\t});\r\n\t</script>\r\n            \r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/simple_social_share.min.css\"
+        type=\"text/css\"/>\r\n    <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/simple_social_share.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\">\r\n        $(document).ready(function(){\r\n
+        \           \r\n            \r\n            $(\"share-button\").simpleSocialShare({\r\n
+        \               sites: \"twitter,email\", \r\n                url: window.location.href,
+        \r\n                title: \"Online application\", \r\n                description:
+        \"Please look at this Planning Application: \", \r\n                shareType:
+        \"button\", \r\n                buttonSide: \"left\", \r\n                orientation:
+        \"horizontal\"\r\n            });\r\n        });\r\n\t</script>\r\n\t<!--
+        #EndEditable -->\r\n\r\n</head>\r\n<body>\r\n\r\n    <a href=\"#pageheading\"
+        class=\"sr-only\">Skip to main content</a>\r\n\r\n    <!-- IDOX PA START -->\r\n
+        \   <div id=\"idox\">\r\n        <div id=\"pa\">\r\n\t\t\t<div id=\"header\"><!--
+        Selector: Selector 1 -->\r\n<style>\r\n#langStyle{float:right; margin-top:
+        10px; margin-right: 30px; background:transparent; font-size:13px; cursor:pointer;
+        border:1px solid #fff !important;border-radius:2px; z-index:999; background-color:
+        #fff; padding:2px;}\r\n#langStyle:hover{text-decoration: underline;}</style>\r\n<div>\r\n\r\n<!--CYS--><a
+        id=\"langStyle\" href=\"/online-applications/applicationDetails.do?activeTab=relatedCases&keyVal=_CARDIFF_DCAPR_126784&lang=CY\">Cymraeg</a><!--CYE-->\r\n</div>\r\n\t\t\t\t<div
+        class=\"container\">\r\n\t\t\t\t\t<div id=\"logo\"><a href=\"https://www.cardiff.gov.uk/\"
+        title=\"Cardiff Council home page\"><img src=\"/online-applications-skin/images/cardiff/logo.png\"
+        alt=\"Council logo\" /><span class=\"sr-only\">Cardiff Council</span></a></div>\r\n\t\t\t\t\t<div
+        id=\"headertitle\"><span></span></div>\r\n\t\t\t\t\t<div class=\"clear\"></div>\r\n\t\t\t\t</div>\t\r\n\t\t\t</div>\r\n\t\t\t<div
+        id=\"breadcrumbs\" class=\"container\">\r\n\t\t\t\t<ul>\r\n\t\t\t\t\t\r\n\t\t\t\t</ul>\r\n\t\t\t</div>\r\n
+        \           <div class=\"container\">\r\n       \t\t\t<div id=\"toolbar\"
+        class=\"nojs\">\r\n                    <ul>\t\r\n                        <li
+        id=\"search\" class=\"main\"><span tabindex=\"0\">Search&nbsp;</span><span
+        class=\"caret\"></span>\r\n   \t\t\t\t\t\t\t<ul>\t\r\n\t\t\t\t\t\t\t\t<!--
+        #BeginLibraryItem \"/Library/searchModulesNavItems.lbi\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \       \r\n            <li id=\"planLinks\">\r\n                <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\"
+        >\r\n                    <span>Planning</span>\r\n                </a>\r\n
+        \               <ul>\r\n                    <li id=\"planBasicSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\">\r\n
+        \                           Simple Search\r\n                        </a>\r\n
+        \                   </li>\r\n\r\n                    <li id=\"planAdvancedSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=advanced&amp;searchType=Application\">\r\n
+        \                           Advanced\r\n                        </a>\r\n                    </li>\r\n
+        \                   <li id=\"planListSearch\">\r\n                        <a
+        href=\"/online-applications/search.do?action=weeklyList&amp;searchType=Application\">\r\n
+        \                           Weekly/Monthly Lists\r\n                        </a>\r\n
+        \                   </li>\r\n                    <li id=\"planPropertySearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=property&amp;type=custom\">\r\n
+        \                           Property Search\r\n                        </a>\r\n
+        \                   </li>\r\n\t\t\t\t\t\r\n                    \r\n\t\t\t\t\t\r\n
+        \               </ul>\r\n            </li>\r\n        \r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        <!-- #EndLibraryItem -->\r\n                        \t</ul>\r\n\t\t\t\t\t\t</li>\r\n
+        \                       <!-- #BeginEditable \"applicationForms\" -->\n\n\n\n\n\n
+        \  \n<!-- #EndEditable -->   \t\t\t\t\r\n                        <li id=\"myprofile\"
+        class=\"main\"><span tabindex=\"0\">My Profile&nbsp;</span><span class=\"caret\"></span>\r\n
+        \                           <ul>\r\n                              <!-- #BeginLibraryItem
+        \"/Library/consulteeInTrayNavItem.lbi\" -->\n\n\n\n\n\n\n    <!-- #EndLibraryItem
+        -->\r\n                                <li><a href=\"/online-applications/registered/displayUserDetails.do\">Profile
+        Details</a></li>\r\n                                <li><a href=\"/online-applications/registered/savedSearch.do?action=display\">Saved
+        Searches</a></li>\r\n                                <li><a href=\"/online-applications/registered/userAdmin.do?action=showNotifiedApplications\">Notified
+        Applications</a></li>\r\n                                <li><a href=\"/online-applications/registered/trackedApplication.do?action=display\">Tracked
+        Applications</a></li>\r\n                                <!-- #BeginEditable
+        \"formSubmissions\" -->\n\n\n\n\n\n\n\n\n<!-- #EndEditable -->    \t\r\n                            </ul>\r\n
+        \                       </li>\r\n                        <li id=\"loginLink\"
+        class=\"main\"><!-- #BeginEditable \"loginlogout\" -->\n\n\n\n\n\n\n\n\n\n\n\t<a
+        href=\"/online-applications/registered/userAdmin.do\">Login</a>\n<!-- #EndEditable
+        --></li>\r\n                        <!-- #BeginEditable \"register\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \  \r\n\r\n\r\n\t<li id=\"register\">\r\n        <a href=\"/online-applications/registrationWizard.do?action=start\">Register</a>\r\n\t</li>\r\n\r\n<!--
+        #EndEditable -->\r\n                        <!-- #BeginLibraryItem \"/Library/applyOnlineNavItems.lbi\"
+        -->\r\n\r\n\r\n\r\n\r\n\r\n<!-- #EndLibraryItem -->\r\n                    </ul>\r\n
+        \   \t\t\t</div>\r\n\r\n    \t\t\t<!-- #BeginEditable \"headlinenews\" --><!--
+        #EndEditable -->\r\n                 \r\n                <div id=\"pageheading\">\r\n
+        \                   <h1><strong>Planning</strong>&nbsp;&ndash;&nbsp;<!-- #BeginEditable
+        \"pageheading\" -->Application Related Items<!-- #EndEditable --></h1>\r\n
+        \                   <!-- #BeginEditable \"helplink\" -->\r\n<p class=\"pagehelp\">\r\n\t<a
+        title=\"Help with this page (opens in a new window)\" rel=\"external\" target=\"_blank\"
+        href=\"/online-applications/help/pagehelp/applications.htm\">\r\n\t\tHelp
+        with this page\r\n\t<span> (opens in a new window)</span>\r\n\t</a>\r\n</p>\r\n<!--
+        #EndEditable -->\r\n                </div>\r\n                \r\n                <!--
+        START WAM CONTENT -->\r\n                <div class=\"content\">\r\n                    <!--
+        #BeginEditable \"errormsg\" --><!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"pagehead\" -->\r\n\r\n    <div class=\"addressCrumb\">\r\n
+        \       <span class=\"caseNumber\">\r\n            \r\n\r\n            \r\n
+        \               19/00503/DCH\r\n            \r\n        </span>\r\n\r\n        <span
+        class=\"divider1\">|</span>\r\n\r\n        \r\n            <span class=\"description\">\r\n
+        \               SINGLE STOREY REAR EXTENSION WITH PITCH ROOF\r\n            </span>\r\n
+        \           \r\n                <span class=\"divider2\">|</span>\r\n            \r\n
+        \       \r\n\r\n        \r\n\r\n        \r\n\r\n        \r\n        \r\n        \r\n
+        \       \r\n        \r\n            \r\n            <span class=\"address\">\r\n
+        \               81 KYLE CRESCENT, WHITCHURCH, CARDIFF, CF14 1SU\r\n            </span>\r\n
+        \       \r\n        \r\n    </div>\r\n\r\n\r\n    <div id=\"applicationTools\">\r\n
+        \       <ul>\r\n            \r\n            \r\n                \r\n                    \r\n
+        \                       \r\n                            \r\n                            \r\n
+        \                               \r\n                                    <li>\r\n
+        \                                       <a href=\"/online-applications/searchResultsBack.do?action=back\"
+        id=\"searchresultsback\">Back to search results</a>\r\n                                    </li>\r\n
+        \                               \r\n                            \r\n                        \r\n
+        \                   \r\n                    \r\n                    \r\n                \r\n
+        \           \r\n\r\n            \r\n\r\n            \r\n            \r\n\r\n
+        \           \r\n\r\n            \r\n            \r\n                \r\n                    <li>\r\n
+        \                       <form name=\"trackForm\" method=\"post\" action=\"/online-applications/registered/trackedApplicationSubmit.do?action=track\"><input
+        type=\"hidden\" name=\"org.apache.struts.taglib.html.TOKEN\" value=\"29bf2f123dcac4b68758826c788ef8f0\"
+        />\r\n                            <input type=\"hidden\" name=\"caseNo\" value=\"19/00503/DCH\"
+        />\r\n                            <input type=\"hidden\" name=\"caseType\"
+        value=\"Application\" />\r\n                            <input type=\"hidden\"
+        name=\"address\" value=\"81 KYLE CRESCENT, WHITCHURCH, CARDIFF, CF14 1SU\"
+        />\r\n                            <input type=\"hidden\" name=\"description\"
+        value=\"SINGLE STOREY REAR EXTENSION WITH PITCH ROOF\" />\r\n                            <input
+        type=\"hidden\" name=\"status\" value=\"Decided\" />\r\n                            <input
+        type=\"hidden\" name=\"trackingStatus\" value=\"Decided\" />\r\n                            <input
+        type=\"hidden\" name=\"caseTechnicalKey\" value=\"_CARDIFF_DCAPR_126784\"
+        />\r\n                            <input class=\"casefiletrack\"\r\n                                   src=\"/online-applications-skin/images/button_track.gif\"\r\n
+        \                                  type=\"image\"\r\n                                   name=\"submit\"\r\n
+        \                                  altKey=\"casedetails.track\"\r\n                                   title=\"Get
+        informed when this item is updated\"/>\r\n                        </form>\r\n
+        \                   </li>\r\n                \r\n\r\n                \r\n
+        \           \r\n\r\n\r\n            \r\n                \r\n             \r\n
+        \           \r\n\r\n            \r\n            \r\n                \r\n            \r\n
+        \           \r\n            \r\n            <li>\r\n                <a href=\"/online-applications/applicationDetails.do?activeTab=printPreview&amp;keyVal=_CARDIFF_DCAPR_126784\"
+        id=\"print\" rel=\"external\">\r\n                    <img src=\"/online-applications-skin/images/button_print.gif\"
+        alt=\"Print summary icon\" width=\"53\" height=\"22\" border=\"0\"/>\r\n                </a>\r\n
+        \           </li>\r\n            \r\n\r\n            \r\n        </ul>\r\n\r\n
+        \   </div>\r\n\r\n\r\n     \r\n\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabs\" -->\r\n    \r\n    <ul class=\"tabs\">\r\n\r\n        \r\n\r\n
+        \           \r\n                \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/applicationDetails.do?activeTab=summary&amp;keyVal=_CARDIFF_DCAPR_126784\"
+        id=\"tab_summary\">\r\n                        <span>\r\n                            Details\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n                \r\n
+        \               <li>\r\n\r\n                     \r\n                    <a
+        href=\"/online-applications/applicationDetails.do?activeTab=makeComment&amp;keyVal=_CARDIFF_DCAPR_126784\"
+        id=\"tab_makeComment\">\r\n                        <span>\r\n                            Comments\r\n
+        \                           \r\n                                \r\n                                (0)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n\r\n
+        \           \r\n                <li class=\"nodocuments\">\r\n                    <span>\r\n
+        \                       Constraints\r\n                        \r\n                            \r\n
+        \                           (0)\r\n                        \r\n                    </span>\r\n
+        \               </li>\r\n            \r\n\r\n        \r\n\r\n            \r\n
+        \               \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/applicationDetails.do?activeTab=documents&amp;keyVal=_CARDIFF_DCAPR_126784\"
+        id=\"tab_documents\">\r\n                        <span>\r\n                            Documents\r\n
+        \                           \r\n                                \r\n                                (6)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n                \r\n
+        \               <li>\r\n\r\n                     \r\n                    <a
+        href=\"/online-applications/applicationDetails.do?activeTab=relatedCases&amp;keyVal=_CARDIFF_DCAPR_126784\"
+        id=\"tab_relatedCases\" class=\"active\">\r\n                        <span>\r\n
+        \                           Related Cases\r\n                            \r\n
+        \                               \r\n                                (1)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                        \r\n
+        \                       \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n\r\n
+        \           \r\n\r\n        \r\n    </ul>\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabsubnav\" --><!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"pagebody\" -->\r\n\r\n    \r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \   <div class=\"tabcontainer toplevel\">\r\n    <div id=\"relatedItems\">\r\n\r\n
+        \       \r\n            \r\n            \r\n\r\n            <!-- Display header
+        -->\r\n            <div id=\"Application\">\r\n                <h3>\r\n                    \r\n
+        \                   \r\n                        Planning Applications\r\n
+        \                   \r\n                    <span>(0)</span>\r\n                </h3>\n\r\n\r\n
+        \               <!-- Display each item -->\r\n                \r\n            </div>\r\n\r\n
+        \       \r\n            \r\n            \r\n\r\n            <!-- Display header
+        -->\r\n            <div id=\"Appeal\">\r\n                <h3>\r\n                    \r\n
+        \                   \r\n                        Planning Appeals\r\n                    \r\n
+        \                   <span>(0)</span>\r\n                </h3>\n\r\n\r\n                <!--
+        Display each item -->\r\n                \r\n            </div>\r\n\r\n        \r\n
+        \           \r\n            \r\n\r\n            <!-- Display header -->\r\n
+        \           <div id=\"Enforcement\">\r\n                <h3>\r\n                    \r\n
+        \                   \r\n                        Planning Enforcements\r\n
+        \                   \r\n                    <span>(0)</span>\r\n                </h3>\n\r\n\r\n
+        \               <!-- Display each item -->\r\n                \r\n            </div>\r\n\r\n
+        \       \r\n            \r\n            \r\n\r\n            <!-- Display header
+        -->\r\n            <div id=\"Property\">\r\n                <h3>\r\n                    \r\n
+        \                   \r\n                        Properties\r\n                    \r\n
+        \                   <span>(1)</span>\r\n                </h3>\n\r\n\r\n                <!--
+        Display each item -->\r\n                \r\n                    <ul>\r\n
+        \                       \r\n                            <li>\r\n                                \r\n
+        \                               \r\n                                \r\n\r\n
+        \                               <a href=\"/online-applications/propertyDetails.do?previousCaseType=Application&amp;keyVal=_CARDIFF_PROPLPI_124800_1&amp;previousCaseNumber=19%2F00503%2FDCH&amp;activeTab=summary&amp;previousKeyVal=_CARDIFF_DCAPR_126784\">\r\n
+        \                                   81 KYLE CRESCENT, WHITCHURCH, CARDIFF,
+        CF14 1SU\r\n                                </a>\r\n\r\n                                <p
+        class=\"metaInfo\">\r\n\r\n                                \r\n\r\n                                \r\n\r\n
+        \                               \r\n                                \r\n                                \r\n
+        \                              </p>\r\n                            </li>\r\n
+        \                       \r\n                    </ul>\r\n                \r\n
+        \           </div>\r\n\r\n        \r\n\r\n    </div>\r\n    </div>\r\n\r\n<!--
+        #EndEditable -->\r\n                    <!-- #BeginEditable \"pagefoot\" --><!--
+        #EndEditable -->\r\n                </div>\r\n                <!-- END WAM
+        CONTENT -->\r\n                \r\n                <p id=\"poweredBy\"><a
+        href=\"http://www.idoxgroup.com/\" target=\"_blank\" title=\"This link will
+        open a new window\"><img src=\"/online-applications-skin/images/idox.gif\"
+        alt=\"an Idox solution\" /></a></p>\r\n            </div>\t\r\n\t\t\t<div
+        id=\"footer\">\r\n\t\t\t\t<div class=\"container\">\t\t\t\t\t\r\n\t\t\t\t\t<div
+        id=\"links\">\r\n\t\t\t\t\t\t<ul>\r\n\t\t\t\t\t\t\t<li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Site_Map/Pages/default.aspx\">Site
+        map</a></li><li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Cookies/Pages/Cookies.aspx\">Cookies</a></li><li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/New_Disclaimer/Pages/default.aspx\">Disclaimer</a></li>\r\n\t\t\t\t\t\t</ul>\r\n\t\t\t\t\t</div>\r\n\t\t\t\t\t<div
+        class=\"clear\"></div>\r\n\t\t\t\t</div>\r\n\t\t\t</div>\r\n\t\t\t<div id=\"footerBottom\">\r\n\t\t\t
+        \   <div class=\"container\">\r\n\t\t\t        <div id=\"footercontent\"><p>&copy;
+        <script type=\"text/javascript\">document.write(new Date().getFullYear());</script>
+        Cardiff Council</p></div>\r\n\t\t\t        <div class=\"clear\"></div>\r\n\t\t\t
+        \   </div>\r\n\t\t\t</div>\r\n        </div>    \r\n    </div>  \r\n    <!--
+        IDOX PA END -->           \r\n\t\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Mon, 15 Apr 2019 11:14:09 GMT
+- request:
+    method: get
+    uri: https://planningonline.cardiff.gov.uk/online-applications/propertyDetails.do?activeTab=summary&keyVal=_CARDIFF_PROPLPI_124800_1&previousCaseNumber=19/00503/DCH&previousCaseType=Application&previousKeyVal=_CARDIFF_DCAPR_126784
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip,deflate,identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mechanize/2.7.6 Ruby/2.6.2p47 (http://github.com/sparklemotion/mechanize/)
+      Accept-Charset:
+      - ISO-8859-1,utf-8;q=0.7,*;q=0.7
+      Accept-Language:
+      - en-us,en;q=0.5
+      Cookie:
+      - JSESSIONID=ss9pKoHL32yHmhJQONSykek96zXCSSZ75skxJ5v1.vmidoxweblve; WSLang-CFC001=EN
+      Host:
+      - planningonline.cardiff.gov.uk
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '300'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - text/html; charset=UTF-8
+      Expires:
+      - Mon, 15 Apr 2019 11:14:42 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ua-Compatible:
+      - IE=edge
+      Server:
+      - Apache
+      Set-Cookie:
+      - WSLang-CFC001=EN; expires=Mon, 15-Apr-2069 11:14:41 GMT; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 15 Apr 2019 11:14:41 GMT
+      Content-Length:
+      - '13513'
+    body:
+      encoding: UTF-8
+      string: "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n    \n\n    \n\n<!DOCTYPE html PUBLIC
+        \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\r\n<html
+        lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\r\n<head>\r\n\r\n\t<!--
+        #BeginEditable \"doctitle\" -->\r\n    <title>\r\n    _CARDIFF_PROPLPI_124800_1\r\n
+        \   |\r\n    \r\n\r\n    \r\n\r\n    \r\n\r\n    \r\n    \r\n    \r\n    \r\n
+        \   \r\n        \r\n        81 KYLE CRESCENT, WHITCHURCH, CARDIFF, CF14 1SU\r\n
+        \   \r\n    \r\n    </title>\r\n<!-- #EndEditable -->\r\n    <!-- #BeginEditable
+        \"metatags\" --><!-- #EndEditable -->\r\n\t\r\n    <meta http-equiv=\"Content-Type\"
+        content=\"text/html; charset=UTF-8\" />\r\n\t\r\n\t<!-- Customer metatags
+        -->\r\n\t\r\n\t\r\n\t<!-- Favicon link -->\r\n    <link rel=\"icon\" href=\"/online-applications-skin/images/cardiff/favicon.ico\"
+        type=\"image/x-icon\" />\r\n\t\r\n    <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/screen.css\"
+        type=\"text/css\" media=\"screen,projection\" />\r\n    <link rel=\"stylesheet\"
+        href=\"/online-applications-skin/styles/theme1.css\" type=\"text/css\"/>\t\r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/print.css\"
+        type=\"text/css\" media=\"print\" />   \r\n\r\n    <script type=\"text/javascript\"
+        src=\"/online-applications-skin/scripts/jquery.min.js\"></script>\r\n    <script
+        type=\"text/javascript\" src=\"/online-applications-skin/scripts/jquery.toolbar.idox.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/common.js\"></script>\r\n
+        \       \r\n\t<!-- Customer Analytics Script -->\r\n\t\r\n\t\r\n    <script
+        type=\"text/javascript\">\r\n    \t$('html').addClass('js');\r\n    \t$(document).ready(function(){\r\n
+        \   \t\t$('.main#apply>span:first-child').attr('tabindex', '0')\r\n    \t});\r\n
+        \   </script>\r\n    \r\n    <!-- #BeginEditable \"mobile\" --><!-- #EndEditable
+        -->\r\n    <!-- #BeginEditable \"head\" --><!-- #EndEditable -->\r\n    <!--
+        #BeginEditable \"webapp\" --><!-- #EndEditable -->\r\n\r\n</head>\r\n<body>\r\n\r\n
+        \   <a href=\"#pageheading\" class=\"sr-only\">Skip to main content</a>\r\n\r\n
+        \   <!-- IDOX PA START -->\r\n    <div id=\"idox\">\r\n        <div id=\"pa\">
+        \r\n\t\t\t<div id=\"header\"><!-- Selector: Selector 1 -->\r\n<style>\r\n#langStyle{float:right;
+        margin-top: 10px; margin-right: 30px; background:transparent; font-size:13px;
+        cursor:pointer; border:1px solid #fff !important;border-radius:2px; z-index:999;
+        background-color: #fff; padding:2px;}\r\n#langStyle:hover{text-decoration:
+        underline;}</style>\r\n<div>\r\n\r\n<!--CYS--><a id=\"langStyle\" href=\"/online-applications/propertyDetails.do?previousCaseType=Application&keyVal=_CARDIFF_PROPLPI_124800_1&previousCaseNumber=19%2f00503%2fDCH&activeTab=summary&previousKeyVal=_CARDIFF_DCAPR_126784&lang=CY\">Cymraeg</a><!--CYE-->\r\n</div>\r\n\t\t\t\t<div
+        class=\"container\">\r\n\t\t\t\t\t<div id=\"logo\"><a href=\"https://www.cardiff.gov.uk/\"
+        title=\"Cardiff Council home page\"><img src=\"/online-applications-skin/images/cardiff/logo.png\"
+        alt=\"Council logo\" /><span class=\"sr-only\">Cardiff Council</span></a></div>\r\n\t\t\t\t\t<div
+        id=\"headertitle\"><span></span></div>\r\n\t\t\t\t\t<div class=\"clear\"></div>\r\n\t\t\t\t</div>\t\r\n\t\t\t</div>\r\n\t\t\t<div
+        id=\"breadcrumbs\" class=\"container\">\r\n\t\t\t\t<ul>\r\n\t\t\t\t\t\r\n\t\t\t\t</ul>\r\n\t\t\t</div>\r\n
+        \           <div class=\"container\">\r\n                <div id=\"toolbar\"
+        class=\"nojs\">\r\n                    <ul>\t\r\n                        <li
+        id=\"search\" class=\"main\"><span tabindex=\"0\">Search&nbsp;</span><span
+        class=\"caret\"></span>\r\n   \t\t\t\t\t\t\t<ul>\t\r\n\t\t\t\t\t\t\t\t<!--
+        #BeginLibraryItem \"/Library/searchModulesNavItems.lbi\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \       \r\n            <li id=\"planLinks\">\r\n                <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\"
+        >\r\n                    <span>Planning</span>\r\n                </a>\r\n
+        \               <ul>\r\n                    <li id=\"planBasicSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\">\r\n
+        \                           Simple Search\r\n                        </a>\r\n
+        \                   </li>\r\n\r\n                    <li id=\"planAdvancedSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=advanced&amp;searchType=Application\">\r\n
+        \                           Advanced\r\n                        </a>\r\n                    </li>\r\n
+        \                   <li id=\"planListSearch\">\r\n                        <a
+        href=\"/online-applications/search.do?action=weeklyList&amp;searchType=Application\">\r\n
+        \                           Weekly/Monthly Lists\r\n                        </a>\r\n
+        \                   </li>\r\n                    <li id=\"planPropertySearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=property&amp;type=custom\">\r\n
+        \                           Property Search\r\n                        </a>\r\n
+        \                   </li>\r\n\t\t\t\t\t\r\n                    \r\n\t\t\t\t\t\r\n
+        \               </ul>\r\n            </li>\r\n        \r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        <!-- #EndLibraryItem -->\r\n                        \t</ul>\r\n\t\t\t\t\t\t</li>\r\n
+        \                       <!-- #BeginEditable \"applicationForms\" -->\n\n\n\n\n\n
+        \  \n<!-- #EndEditable -->   \t\t\t\t\r\n                        <li id=\"myprofile\"
+        class=\"main\"><span tabindex=\"0\">My Profile&nbsp;</span><span class=\"caret\"></span>\r\n
+        \                           <ul>\r\n                              <!-- #BeginLibraryItem
+        \"/Library/consulteeInTrayNavItem.lbi\" -->\n\n\n\n\n\n\n    <!-- #EndLibraryItem
+        -->\r\n                                <li><a href=\"/online-applications/registered/displayUserDetails.do\">Profile
+        Details</a></li>\r\n                                <li><a href=\"/online-applications/registered/savedSearch.do?action=display\">Saved
+        Searches</a></li>\r\n                                <li><a href=\"/online-applications/registered/userAdmin.do?action=showNotifiedApplications\">Notified
+        Applications</a></li>\r\n                                <li><a href=\"/online-applications/registered/trackedApplication.do?action=display\">Tracked
+        Applications</a></li>\r\n                                <!-- #BeginEditable
+        \"formSubmissions\" -->\n\n\n\n\n\n\n\n\n<!-- #EndEditable -->    \t\r\n                            </ul>\r\n
+        \                       </li>\r\n                        <li id=\"loginLink\"
+        class=\"main\"><!-- #BeginEditable \"loginlogout\" -->\n\n\n\n\n\n\n\n\n\n\n\t<a
+        href=\"/online-applications/registered/userAdmin.do\">Login</a>\n<!-- #EndEditable
+        --></li>\r\n                        <!-- #BeginEditable \"register\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \  \r\n\r\n\r\n\t<li id=\"register\">\r\n        <a href=\"/online-applications/registrationWizard.do?action=start\">Register</a>\r\n\t</li>\r\n\r\n<!--
+        #EndEditable -->\r\n                        <!-- #BeginLibraryItem \"/Library/applyOnlineNavItems.lbi\"
+        -->\r\n\r\n\r\n\r\n\r\n\r\n<!-- #EndLibraryItem -->\r\n                    </ul>\r\n
+        \   \t\t\t</div>\r\n                \r\n                <div id=\"pageheading\">\r\n
+        \                   <h1><!-- #BeginEditable \"pageheading\" -->Property Address<!--
+        #EndEditable --></h1>\r\n                    <!-- #BeginEditable \"helplink\"
+        -->\r\n<p class=\"pagehelp\">\r\n\t<a title=\"Help with this page (opens in
+        a new window)\" rel=\"external\" target=\"_blank\" href=\"/online-applications/help/pagehelp/properties.htm\">\r\n\t\tHelp
+        with this page\r\n\t<span> (opens in a new window)</span>\r\n\t</a>\r\n</p>\r\n<!--
+        #EndEditable -->\r\n                </div>\r\n        \r\n                <!--
+        START WAM CONTENT -->\r\n                <div class=\"content\">\r\n                    <!--
+        #BeginEditable \"errormsg\" -->\n        \n        \n\n        \n        \n
+        \   <!-- #EndEditable -->\r\n                    <!-- #BeginEditable \"pagehead\"
+        -->\r\n\r\n    <div class=\"addressCrumb\">\r\n        <span class=\"caseNumber\">\r\n
+        \           \r\n                100100033792 \r\n            \r\n\r\n            \r\n
+        \       </span>\r\n\r\n        <span class=\"divider1\">|</span>\r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        \r\n\r\n        \r\n        \r\n        \r\n        \r\n
+        \       \r\n            \r\n            <span class=\"address\">\r\n                81
+        KYLE CRESCENT, WHITCHURCH, CARDIFF, CF14 1SU\r\n            </span>\r\n        \r\n
+        \       \r\n    </div>\r\n\r\n\r\n    <div id=\"applicationTools\">\r\n        <ul>\r\n
+        \           \r\n            \r\n\r\n            \r\n\r\n            \r\n            \r\n
+        \               <li>\r\n                    <a href=\"/online-applications/applicationDetails.do?keyVal=_CARDIFF_DCAPR_126784&amp;activeTab=summary\"
+        id=\"searchresultsback\">\r\n                        Planning Application\r\n
+        \                       \r\n                        \r\n                            19/00503/DCH\r\n
+        \                       \r\n                    </a>\r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n            \r\n            \r\n\r\n\r\n
+        \           \r\n                \r\n             \r\n            \r\n\r\n
+        \           \r\n            \r\n                \r\n            \r\n            \r\n
+        \           \r\n            <li>\r\n                <a href=\"/online-applications/propertyDetails.do?activeTab=printPreview&amp;keyVal=_CARDIFF_PROPLPI_124800_1\"
+        id=\"print\" rel=\"external\">\r\n                    <img src=\"/online-applications-skin/images/button_print.gif\"
+        alt=\"Print summary icon\" width=\"53\" height=\"22\" border=\"0\"/>\r\n                </a>\r\n
+        \           </li>\r\n            \r\n\r\n            \r\n        </ul>\r\n\r\n
+        \   </div>\r\n\r\n\r\n     \r\n\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabs\" -->\r\n    \r\n    <ul class=\"tabs\">\r\n\r\n        \r\n\r\n
+        \           \r\n                \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/propertyDetails.do?activeTab=summary&amp;keyVal=_CARDIFF_PROPLPI_124800_1\"
+        id=\"tab_summary\" class=\"active\">\r\n                        <span>\r\n
+        \                           Address\r\n                            \r\n                        </span>\r\n
+        \                   </a>\r\n\r\n                    \r\n                    \r\n
+        \                   \r\n                        \r\n                        \r\n
+        \                   \r\n                </li>\r\n            \r\n\r\n            \r\n\r\n
+        \       \r\n\r\n            \r\n                \r\n                <li>\r\n\r\n
+        \                    \r\n                    <a href=\"/online-applications/propertyDetails.do?activeTab=relatedCases&amp;keyVal=_CARDIFF_PROPLPI_124800_1\"
+        id=\"tab_relatedCases\">\r\n                        <span>\r\n                            Property
+        History\r\n                            \r\n                                \r\n
+        \                               (5)\r\n                            \r\n                        </span>\r\n
+        \                   </a>\r\n\r\n                    \r\n                    \r\n
+        \                   \r\n                </li>\r\n            \r\n\r\n            \r\n\r\n
+        \       \r\n\r\n            \r\n                \r\n                <li>\r\n\r\n
+        \                    \r\n                    <a href=\"/online-applications/propertyDetails.do?activeTab=constraints&amp;keyVal=_CARDIFF_PROPLPI_124800_1\"
+        id=\"tab_constraints\">\r\n                        <span>\r\n                            Constraints\r\n
+        \                           \r\n                                \r\n                                (1)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n\r\n
+        \           \r\n\r\n        \r\n    </ul>\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabsubnav\" --><!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"pagebody\" -->\n    \r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\n
+        \   \n        \n        \n    \n\n    \n    \n    \n    \n    \n        \n
+        \       \n    \n\n    <div class=\"tabcontainer toplevel\">\n\n        \n
+        \       \n        \n            \n            <table id=\"propertyAddress\"
+        summary=\"Property address\">\r\n<tr class=\"row0\">\r\n<th scope=\"row\">UPRN:</th>\r\n<td>100100033792</td>\r\n</tr>\r\n<tr
+        class=\"row1\">\r\n<th scope=\"row\">Full Address:</th>\r\n<td>81 KYLE CRESCENT,
+        WHITCHURCH, CARDIFF, CF14 1SU</td>\r\n</tr>\r\n<tr class=\"row1\">\r\n<th
+        scope=\"row\">Property Number:</th>\r\n<td>81</td>\r\n</tr>\r\n<tr class=\"row0\">\r\n<th
+        scope=\"row\">Street:</th>\r\n<td>KYLE CRESCENT</td>\r\n</tr>\r\n<tr class=\"row1\">\r\n<th
+        scope=\"row\">Town:</th>\r\n<td>CARDIFF</td>\r\n</tr>\r\n<tr class=\"row0\">\r\n<th
+        scope=\"row\">Postcode:</th>\r\n<td>CF14 1SU</td>\r\n</tr>\r\n<tr class=\"row1\">\r\n<th
+        scope=\"row\">Ward:</th>\r\n<td>HEATH</td>\r\n</tr>\r\n<tr class=\"row0\">\r\n<th
+        scope=\"row\">Parish:</th>\r\n<td/>\r\n</tr>\r\n</table>\r\n\n        \n\n
+        \       \n        \n\n        \n        \n            \n        \n\n    </div>\n<!--
+        #EndEditable -->\r\n                    <!-- #BeginEditable \"pagefoot\" --><!--
+        #EndEditable -->\r\n                </div>\r\n                <!-- END WAM
+        CONTENT -->\r\n                \r\n                <p id=\"poweredBy\"><a
+        href=\"http://www.idoxgroup.com/\" target=\"_blank\" title=\"This link will
+        open a new window\"><img src=\"/online-applications-skin/images/idox.gif\"
+        alt=\"an Idox solution\" /></a></p>\r\n            </div>\r\n\t\t\t<div id=\"footer\">\r\n\t\t\t\t<div
+        class=\"container\">\t\t\t\t\t\r\n\t\t\t\t\t<div id=\"links\">\r\n\t\t\t\t\t\t<ul>\r\n\t\t\t\t\t\t\t<li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/Site_Map/Pages/default.aspx\">Site
+        map</a></li><li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Cookies/Pages/Cookies.aspx\">Cookies</a></li><li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/New_Disclaimer/Pages/default.aspx\">Disclaimer</a></li>\r\n\t\t\t\t\t\t</ul>\r\n\t\t\t\t\t</div>\r\n\t\t\t\t\t<div
+        class=\"clear\"></div>\r\n\t\t\t\t</div>\r\n\t\t\t</div>\r\n\t\t\t<div id=\"footerBottom\">\r\n\t\t\t
+        \   <div class=\"container\">\r\n\t\t\t        <div id=\"footercontent\"><p>&copy;
+        <script type=\"text/javascript\">document.write(new Date().getFullYear());</script>
+        Cardiff Council</p></div>\r\n\t\t\t        <div class=\"clear\"></div>\r\n\t\t\t
+        \   </div>\r\n\t\t\t</div>\r\n        </div>\r\n    </div>\r\n    <!-- IDOX
+        PA END -->\r\n\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Mon, 15 Apr 2019 11:14:11 GMT
+- request:
+    method: get
+    uri: https://planningonline.cardiff.gov.uk/online-applications/applicationDetails.do?activeTab=summary&keyVal=_CARDIFF_DCAPR_126566
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip,deflate,identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mechanize/2.7.6 Ruby/2.6.2p47 (http://github.com/sparklemotion/mechanize/)
+      Accept-Charset:
+      - ISO-8859-1,utf-8;q=0.7,*;q=0.7
+      Accept-Language:
+      - en-us,en;q=0.5
+      Cookie:
+      - JSESSIONID=ss9pKoHL32yHmhJQONSykek96zXCSSZ75skxJ5v1.vmidoxweblve; WSLang-CFC001=EN
+      Host:
+      - planningonline.cardiff.gov.uk
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '300'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - text/html; charset=UTF-8
+      Expires:
+      - Mon, 15 Apr 2019 11:14:58 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ua-Compatible:
+      - IE=edge
+      Server:
+      - Apache
+      Set-Cookie:
+      - WSLang-CFC001=EN; expires=Mon, 15-Apr-2069 11:14:53 GMT; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 15 Apr 2019 11:14:58 GMT
+      Content-Length:
+      - '28341'
+    body:
+      encoding: UTF-8
+      string: "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n    \n\n    \n\n<!DOCTYPE html PUBLIC
+        \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\r\n<html
+        lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\r\n<head>\r\n\t\r\n\t<!--
+        #BeginEditable \"doctitle\" -->\r\n    <title>\r\n    19/00309/MJR\r\n    |\r\n
+        \   \r\n        HEATING AND COOLING PLANT TO THE ROOF AND REAR COURTYARD\r\n
+        \       \r\n        |\r\n        \r\n    \r\n\r\n    \r\n\r\n    \r\n\r\n
+        \   \r\n    \r\n    \r\n    \r\n    \r\n        \r\n        23 WOMANBY STREET,
+        CITY CENTRE, CARDIFF, CF10 1BR\r\n    \r\n    \r\n    </title>\r\n<!-- #EndEditable
+        -->\r\n    <!-- #BeginEditable \"metatags\" --><!-- #EndEditable -->\r\n\t\r\n
+        \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
+        />\r\n\t\r\n\t<!-- Customer metatags -->\r\n\t\r\n\t\r\n\t<!-- Favicon link
+        -->\r\n    <link rel=\"icon\" href=\"/online-applications-skin/images/cardiff/favicon.ico\"
+        type=\"image/x-icon\" />\r\n\t\r\n    <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/screen.css\"
+        type=\"text/css\" media=\"screen,projection\" />\r\n    <link rel=\"stylesheet\"
+        href=\"/online-applications-skin/styles/theme1.css\" type=\"text/css\"/>    \r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/print.css\"
+        type=\"text/css\" media=\"print\" />\r\n\t\r\n    <script type=\"text/javascript\"
+        src=\"/online-applications-skin/scripts/jquery.min.js\"></script>\r\n    <script
+        type=\"text/javascript\" src=\"/online-applications-skin/scripts/jquery.toolbar.idox.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/common.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/checkbox.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/amplify.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/createCommentCookie.js\"></script>\r\n
+        \       \r\n\t<!-- Customer Analytics Script -->\r\n\t\r\n\t\r\n    <script
+        type=\"text/javascript\">\r\n    \t$('html').addClass('js');\r\n    \t$(document).ready(function(){\r\n
+        \   \t\t$('.main#apply>span:first-child').attr('tabindex', '0')\r\n    \t});\r\n
+        \   </script>\r\n    \r\n    <!-- #BeginEditable \"mobile\" --><!-- #EndEditable
+        -->\r\n    <!-- #BeginEditable \"head\" -->\r\n\t<script type=\"text/javascript\">\r\n\t
+        \   jQuery(document).ready(function() {\t\r\n\t\t\tjQuery('#pa').before('<img
+        src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\" id=\"preload\"
+        />');\r\n\t\t\tjQuery('#preload').hide();\r\n\t\t\tjQuery('.tabs a#tab_documents').click(
+        function(event) {\r\n\t\t\t\t  window.clearTimeout(window.timeOutId);\r\n\t\t\t\t
+        \ window.timeOutId = window.setTimeout(function() {\r\n\t\t\t\t\t\tjQuery('.content').before('<div
+        id=\"overlay\"></div><div id=\"loading\"><div id=\"message\">Loading. Please
+        wait.... <img src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\"
+        height=\"19\" width=\"220\" style=\"background:#fff;\" /></div></div>');\r\n\t\t\t\t
+        \ },10);\r\n\t\t\t\t});\r\n\t\t\tjQuery('p.associateddocument a').click( function(event)
+        {\r\n\t\t\t\t  window.clearTimeout(window.timeOutId);\r\n\t\t\t\t  window.timeOutId
+        = window.setTimeout(function() {\r\n\t\t\t\t\t\tjQuery('.content').before('<div
+        id=\"overlay\"></div><div id=\"loading\"><div id=\"message\">Loading. Please
+        wait.... <img src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\"
+        height=\"19\" width=\"220\" style=\"background:#fff;\" /></div></div>');\r\n\t\t\t\t
+        \ },10);\r\n\t\t\t\t});\r\n\r\n\t\t});\r\n    </script>\r\n    \r\n    <link
+        rel=\"stylesheet\" href=\"/online-applications-skin/styles/simple_social_share.min.css\"
+        type=\"text/css\"/>\r\n    <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/simple_social_share.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\">\r\n        $(document).ready(function(){\r\n
+        \           \r\n            \r\n            $(\"share-button\").simpleSocialShare({\r\n
+        \               sites: \"twitter,email\", \r\n                url: window.location.href,
+        \r\n                title: \"Online application\", \r\n                description:
+        \"Please look at this Planning Application: \", \r\n                shareType:
+        \"button\", \r\n                buttonSide: \"left\", \r\n                orientation:
+        \"horizontal\"\r\n            });\r\n        });\r\n\t</script>\r\n\t<!--
+        #EndEditable -->\r\n    <!-- #BeginEditable \"webapp\" --><!-- #EndEditable
+        -->\r\n\r\n</head>\r\n<body>\r\n\r\n    <a href=\"#pageheading\" class=\"sr-only\">Skip
+        to main content</a>\r\n\r\n    <!-- IDOX PA START -->\r\n    <div id=\"idox\">\r\n
+        \       <div id=\"pa\">\r\n\t\t\t<div id=\"header\"><!-- Selector: Selector
+        1 -->\r\n<style>\r\n#langStyle{float:right; margin-top: 10px; margin-right:
+        30px; background:transparent; font-size:13px; cursor:pointer; border:1px solid
+        #fff !important;border-radius:2px; z-index:999; background-color: #fff; padding:2px;}\r\n#langStyle:hover{text-decoration:
+        underline;}</style>\r\n<div>\r\n\r\n<!--CYS--><a id=\"langStyle\" href=\"/online-applications/applicationDetails.do?keyVal=_CARDIFF_DCAPR_126566&activeTab=summary&lang=CY\">Cymraeg</a><!--CYE-->\r\n</div>\r\n\t\t\t\t<div
+        class=\"container\">\r\n\t\t\t\t\t<div id=\"logo\"><a href=\"https://www.cardiff.gov.uk/\"
+        title=\"Cardiff Council home page\"><img src=\"/online-applications-skin/images/cardiff/logo.png\"
+        alt=\"Council logo\" /><span class=\"sr-only\">Cardiff Council</span></a></div>\r\n\t\t\t\t\t<div
+        id=\"headertitle\"><span></span></div>\r\n\t\t\t\t\t<div class=\"clear\"></div>\r\n\t\t\t\t</div>\t\r\n\t\t\t</div>\r\n\t\t\t<div
+        id=\"breadcrumbs\" class=\"container\">\r\n\t\t\t\t<ul>\r\n\t\t\t\t\t\r\n\t\t\t\t</ul>\r\n\t\t\t</div>\r\n
+        \           <div class=\"container\">\r\n       \t\t\t<div id=\"toolbar\"
+        class=\"nojs\">\r\n                    <ul>\t\r\n                        <li
+        id=\"search\" class=\"main\"><span tabindex=\"0\">Search&nbsp;</span><span
+        class=\"caret\"></span>\r\n   \t\t\t\t\t\t\t<ul>\t\r\n\t\t\t\t\t\t\t\t<!--
+        #BeginLibraryItem \"/Library/searchModulesNavItems.lbi\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \       \r\n            <li id=\"planLinks\">\r\n                <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\"
+        >\r\n                    <span>Planning</span>\r\n                </a>\r\n
+        \               <ul>\r\n                    <li id=\"planBasicSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\">\r\n
+        \                           Simple Search\r\n                        </a>\r\n
+        \                   </li>\r\n\r\n                    <li id=\"planAdvancedSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=advanced&amp;searchType=Application\">\r\n
+        \                           Advanced\r\n                        </a>\r\n                    </li>\r\n
+        \                   <li id=\"planListSearch\">\r\n                        <a
+        href=\"/online-applications/search.do?action=weeklyList&amp;searchType=Application\">\r\n
+        \                           Weekly/Monthly Lists\r\n                        </a>\r\n
+        \                   </li>\r\n                    <li id=\"planPropertySearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=property&amp;type=custom\">\r\n
+        \                           Property Search\r\n                        </a>\r\n
+        \                   </li>\r\n\t\t\t\t\t\r\n                    \r\n\t\t\t\t\t\r\n
+        \               </ul>\r\n            </li>\r\n        \r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        <!-- #EndLibraryItem -->\r\n                        \t</ul>\r\n\t\t\t\t\t\t</li>\r\n
+        \                       <!-- #BeginEditable \"applicationForms\" -->\n\n\n\n\n\n
+        \  \n<!-- #EndEditable -->   \t\t\t\t\r\n                        <li id=\"myprofile\"
+        class=\"main\"><span tabindex=\"0\">My Profile&nbsp;</span><span class=\"caret\"></span>\r\n
+        \                           <ul>\r\n                              <!-- #BeginLibraryItem
+        \"/Library/consulteeInTrayNavItem.lbi\" -->\n\n\n\n\n\n\n    <!-- #EndLibraryItem
+        -->\r\n                                <li><a href=\"/online-applications/registered/displayUserDetails.do\">Profile
+        Details</a></li>\r\n                                <li><a href=\"/online-applications/registered/savedSearch.do?action=display\">Saved
+        Searches</a></li>\r\n                                <li><a href=\"/online-applications/registered/userAdmin.do?action=showNotifiedApplications\">Notified
+        Applications</a></li>\r\n                                <li><a href=\"/online-applications/registered/trackedApplication.do?action=display\">Tracked
+        Applications</a></li>\r\n                                <!-- #BeginEditable
+        \"formSubmissions\" -->\n\n\n\n\n\n\n\n\n<!-- #EndEditable -->    \t\r\n                            </ul>\r\n
+        \                       </li>\r\n                        <li id=\"loginLink\"
+        class=\"main\"><!-- #BeginEditable \"loginlogout\" -->\n\n\n\n\n\n\n\n\n\n\n\t<a
+        href=\"/online-applications/registered/userAdmin.do\">Login</a>\n<!-- #EndEditable
+        --></li>\r\n                        <!-- #BeginEditable \"register\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \  \r\n\r\n\r\n\t<li id=\"register\">\r\n        <a href=\"/online-applications/registrationWizard.do?action=start\">Register</a>\r\n\t</li>\r\n\r\n<!--
+        #EndEditable -->\r\n                        <!-- #BeginLibraryItem \"/Library/applyOnlineNavItems.lbi\"
+        -->\r\n\r\n\r\n\r\n\r\n\r\n<!-- #EndLibraryItem -->\r\n                    </ul>\r\n
+        \   \t\t\t</div>\r\n\r\n    \t\t\t<!-- #BeginEditable \"headlinenews\" --><!--
+        #EndEditable -->\r\n                 \r\n                <div id=\"pageheading\">\r\n
+        \                   <h1><strong>Planning</strong>&nbsp;&ndash;&nbsp;<!-- #BeginEditable
+        \"pageheading\" -->Application Summary<!-- #EndEditable --></h1>\r\n                    <!--
+        #BeginEditable \"helplink\" -->\r\n<p class=\"pagehelp\">\r\n\t<a title=\"Help
+        with this page (opens in a new window)\" rel=\"external\" target=\"_blank\"
+        href=\"/online-applications/help/pagehelp/applications.htm\">\r\n\t\tHelp
+        with this page\r\n\t<span> (opens in a new window)</span>\r\n\t</a>\r\n</p>\r\n<!--
+        #EndEditable -->\r\n                </div>\r\n                \r\n                <!--
+        START WAM CONTENT -->\r\n                <div class=\"content\">\r\n                    <!--
+        #BeginEditable \"errormsg\" -->\n        \n        \n\n        \n        \n
+        \   <!-- #EndEditable -->\r\n                    <!-- #BeginEditable \"pagehead\"
+        -->\r\n\r\n    <div class=\"addressCrumb\">\r\n        <span class=\"caseNumber\">\r\n
+        \           \r\n\r\n            \r\n                19/00309/MJR\r\n            \r\n
+        \       </span>\r\n\r\n        <span class=\"divider1\">|</span>\r\n\r\n        \r\n
+        \           <span class=\"description\">\r\n                HEATING AND COOLING
+        PLANT TO THE ROOF AND REAR COURTYARD\r\n            </span>\r\n            \r\n
+        \               <span class=\"divider2\">|</span>\r\n            \r\n        \r\n\r\n
+        \       \r\n\r\n        \r\n\r\n        \r\n        \r\n        \r\n        \r\n
+        \       \r\n            \r\n            <span class=\"address\">\r\n                23
+        WOMANBY STREET, CITY CENTRE, CARDIFF, CF10 1BR\r\n            </span>\r\n
+        \       \r\n        \r\n    </div>\r\n\r\n\r\n    <div id=\"applicationTools\">\r\n
+        \       <ul>\r\n            \r\n            \r\n                \r\n                    \r\n
+        \                       \r\n                            \r\n                            \r\n
+        \                               \r\n                                    <li>\r\n
+        \                                       <a href=\"/online-applications/searchResultsBack.do?action=back\"
+        id=\"searchresultsback\">Back to search results</a>\r\n                                    </li>\r\n
+        \                               \r\n                            \r\n                        \r\n
+        \                   \r\n                    \r\n                    \r\n                \r\n
+        \           \r\n\r\n            \r\n\r\n            \r\n            \r\n\r\n
+        \           \r\n\r\n            \r\n            \r\n                \r\n                    <li>\r\n
+        \                       <form name=\"trackForm\" method=\"post\" action=\"/online-applications/registered/trackedApplicationSubmit.do?action=track\"><input
+        type=\"hidden\" name=\"org.apache.struts.taglib.html.TOKEN\" value=\"7dc6dd6c4d1d2969f487576bd4aee86e\"
+        />\r\n                            <input type=\"hidden\" name=\"caseNo\" value=\"19/00309/MJR\"
+        />\r\n                            <input type=\"hidden\" name=\"caseType\"
+        value=\"Application\" />\r\n                            <input type=\"hidden\"
+        name=\"address\" value=\"23 WOMANBY STREET, CITY CENTRE, CARDIFF, CF10 1BR\"
+        />\r\n                            <input type=\"hidden\" name=\"description\"
+        value=\"HEATING AND COOLING PLANT TO THE ROOF AND REAR COURTYARD\" />\r\n
+        \                           <input type=\"hidden\" name=\"status\" value=\"Decided\"
+        />\r\n                            <input type=\"hidden\" name=\"trackingStatus\"
+        value=\"Decided\" />\r\n                            <input type=\"hidden\"
+        name=\"caseTechnicalKey\" value=\"_CARDIFF_DCAPR_126566\" />\r\n                            <input
+        class=\"casefiletrack\"\r\n                                   src=\"/online-applications-skin/images/button_track.gif\"\r\n
+        \                                  type=\"image\"\r\n                                   name=\"submit\"\r\n
+        \                                  altKey=\"casedetails.track\"\r\n                                   title=\"Get
+        informed when this item is updated\"/>\r\n                        </form>\r\n
+        \                   </li>\r\n                \r\n\r\n                \r\n
+        \           \r\n\r\n\r\n            \r\n                \r\n             \r\n
+        \           \r\n\r\n            \r\n            \r\n                \r\n            \r\n
+        \           \r\n            \r\n            <li>\r\n                <a href=\"/online-applications/applicationDetails.do?activeTab=printPreview&amp;keyVal=_CARDIFF_DCAPR_126566\"
+        id=\"print\" rel=\"external\">\r\n                    <img src=\"/online-applications-skin/images/button_print.gif\"
+        alt=\"Print summary icon\" width=\"53\" height=\"22\" border=\"0\"/>\r\n                </a>\r\n
+        \           </li>\r\n            \r\n\r\n            \r\n        </ul>\r\n\r\n
+        \   </div>\r\n\r\n\r\n     \r\n\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabs\" -->\r\n    \r\n    <ul class=\"tabs\">\r\n\r\n        \r\n\r\n
+        \           \r\n                \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/applicationDetails.do?activeTab=summary&amp;keyVal=_CARDIFF_DCAPR_126566\"
+        id=\"tab_summary\" class=\"active\">\r\n                        <span>\r\n
+        \                           Details\r\n                            \r\n                        </span>\r\n
+        \                   </a>\r\n\r\n                    \r\n                    \r\n
+        \                   \r\n                        \r\n                        \r\n\r\n
+        \                           <ul class=\"subtabs\">\r\n                                \r\n
+        \                                   \r\n                                        <li>\r\n
+        \                                           \r\n                                            <a
+        href=\"/online-applications/applicationDetails.do?activeTab=summary&amp;keyVal=_CARDIFF_DCAPR_126566\"
+        id=\"subtab_summary\" class=\"active\">\r\n                                                <span>\r\n
+        \                                                   Summary\r\n                                                    \r\n
+        \                                               </span>\r\n                                            </a>\r\n
+        \                                       </li>\r\n                                    \r\n
+        \                               \r\n                                    \r\n
+        \                                       <li>\r\n                                            \r\n
+        \                                           <a href=\"/online-applications/applicationDetails.do?activeTab=details&amp;keyVal=_CARDIFF_DCAPR_126566\"
+        id=\"subtab_details\">\r\n                                                <span>\r\n
+        \                                                   Further Information\r\n
+        \                                                   \r\n                                                </span>\r\n
+        \                                           </a>\r\n                                        </li>\r\n
+        \                                   \r\n                                \r\n
+        \                                   \r\n                                        <li>\r\n
+        \                                           \r\n                                            <a
+        href=\"/online-applications/applicationDetails.do?activeTab=contacts&amp;keyVal=_CARDIFF_DCAPR_126566\"
+        id=\"subtab_contacts\">\r\n                                                <span>\r\n
+        \                                                   Contacts\r\n                                                    \r\n
+        \                                               </span>\r\n                                            </a>\r\n
+        \                                       </li>\r\n                                    \r\n
+        \                               \r\n                                    \r\n
+        \                                       <li>\r\n                                            \r\n
+        \                                           <a href=\"/online-applications/applicationDetails.do?activeTab=dates&amp;keyVal=_CARDIFF_DCAPR_126566\"
+        id=\"subtab_dates\">\r\n                                                <span>\r\n
+        \                                                   Important Dates\r\n                                                    \r\n
+        \                                               </span>\r\n                                            </a>\r\n
+        \                                       </li>\r\n                                    \r\n
+        \                               \r\n                            </ul>\r\n\r\n
+        \                       \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n                \r\n
+        \               <li>\r\n\r\n                     \r\n                    <a
+        href=\"/online-applications/applicationDetails.do?activeTab=makeComment&amp;keyVal=_CARDIFF_DCAPR_126566\"
+        id=\"tab_makeComment\">\r\n                        <span>\r\n                            Comments\r\n
+        \                           \r\n                                \r\n                                (0)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n\r\n
+        \           \r\n                <li class=\"nodocuments\">\r\n                    <span>\r\n
+        \                       Constraints\r\n                        \r\n                            \r\n
+        \                           (0)\r\n                        \r\n                    </span>\r\n
+        \               </li>\r\n            \r\n\r\n        \r\n\r\n            \r\n
+        \               \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/applicationDetails.do?activeTab=documents&amp;keyVal=_CARDIFF_DCAPR_126566\"
+        id=\"tab_documents\">\r\n                        <span>\r\n                            Documents\r\n
+        \                           \r\n                                \r\n                                (11)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n                \r\n
+        \               <li>\r\n\r\n                     \r\n                    <a
+        href=\"/online-applications/applicationDetails.do?activeTab=relatedCases&amp;keyVal=_CARDIFF_DCAPR_126566\"
+        id=\"tab_relatedCases\">\r\n                        <span>\r\n                            Related
+        Cases\r\n                            \r\n                                \r\n
+        \                               (1)\r\n                            \r\n                        </span>\r\n
+        \                   </a>\r\n\r\n                    \r\n                    \r\n
+        \                   \r\n                </li>\r\n            \r\n\r\n            \r\n\r\n
+        \       \r\n\r\n            \r\n\r\n            \r\n\r\n        \r\n    </ul>\r\n<!--
+        #EndEditable -->\r\n                    <!-- #BeginEditable \"tabsubnav\"
+        --><!-- #EndEditable -->\r\n                    <!-- #BeginEditable \"pagebody\"
+        -->\n    \r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\n
+        \   \n        \n        \n    \n\n    \n    \n    \n    \n    \n\n    <div
+        class=\"tabcontainer\">\n\n        \n        \n        \n\n        \n        \n\n
+        \           \n            \n                \n            \n\n            \n
+        \               <table id=\"simpleDetailsTable\" summary=\"Case Details\">\n\n
+        \                   \n                    \n                        \n                            <tr>\n
+        \                               <th scope=\"row\" width=\"40%\">\n                                    Reference\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            19/00309/MJR\n
+        \                                       \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Alternative Reference\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            PP-07606471\n
+        \                                       \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Application Received\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            Thu
+        14 Feb 2019\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Application Validated\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            Thu
+        14 Feb 2019\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Address\n                                </th>\n
+        \                               <td>\n                                    \n
+        \                                       \n                                        \n
+        \                                           23 WOMANBY STREET, CITY CENTRE,
+        CARDIFF, CF10 1BR\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Proposal\n                                </th>\n
+        \                               <td>\n                                    \n
+        \                                       \n                                        \n
+        \                                           HEATING AND COOLING PLANT TO THE
+        ROOF AND REAR COURTYARD\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Status\n                                </th>\n
+        \                               <td>\n                                    \n
+        \                                       \n                                            <span
+        class=\"caseDetailsStatus\">Decided</span>\n                                        \n
+        \                                       \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Decision\n                                </th>\n
+        \                               <td>\n                                    \n
+        \                                       \n                                        \n
+        \                                           Permission be granted\n                                        \n
+        \                                   \n                                </td>\n
+        \                           </tr>\n                        \n                    \n
+        \                       \n                            <tr>\n                                <th
+        scope=\"row\" width=\"40%\">\n                                    Decision
+        Issued Date\n                                </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            Mon
+        08 Apr 2019\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Appeal Decision\n                                </th>\n
+        \                               <td>\n                                    \n
+        \                                       \n                                        \n
+        \                                           \n                                        \n
+        \                                   \n                                </td>\n
+        \                           </tr>\n                        \n                    \n\n
+        \               </table>\n\n                \n                \n\n                \n\n
+        \           \n\n            \n\n        \n\n        \n        \n            \n
+        \               <div id=\"summaryInfo\">\n                    \n                    \n
+        \                   \n                        \n                            \n
+        \                       \n                    \n\n                    \n                    \n
+        \                       <p class=\"associateddocument\">There are <a href=\"/online-applications/applicationDetails.do?activeTab=documents&amp;keyVal=_CARDIFF_DCAPR_126566\">11
+        documents</a> associated with this application.</p><p class=\"associatedcase\">There
+        are 0 cases associated with this application.</p><p class=\"associatedproperty\">There
+        is <a href=\"/online-applications/applicationDetails.do?activeTab=relatedCases&amp;keyVal=_CARDIFF_DCAPR_126566\">1
+        property</a> associated with this application.</p>\r\n\n                    \n
+        \               </div>\n            \n        \n\n    </div>\n<!-- #EndEditable
+        -->\r\n                    <!-- #BeginEditable \"pagefoot\" --><!-- #EndEditable
+        -->\r\n                </div>\r\n                <!-- END WAM CONTENT -->\r\n
+        \               \r\n                <p id=\"poweredBy\"><a href=\"http://www.idoxgroup.com/\"
+        target=\"_blank\" title=\"This link will open a new window\"><img src=\"/online-applications-skin/images/idox.gif\"
+        alt=\"an Idox solution\" /></a></p>\r\n            </div>\t\r\n\t\t\t<div
+        id=\"footer\">\r\n\t\t\t\t<div class=\"container\">\t\t\t\t\t\r\n\t\t\t\t\t<div
+        id=\"links\">\r\n\t\t\t\t\t\t<ul>\r\n\t\t\t\t\t\t\t<li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Site_Map/Pages/default.aspx\">Site
+        map</a></li><li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Cookies/Pages/Cookies.aspx\">Cookies</a></li><li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/New_Disclaimer/Pages/default.aspx\">Disclaimer</a></li>\r\n\t\t\t\t\t\t</ul>\r\n\t\t\t\t\t</div>\r\n\t\t\t\t\t<div
+        class=\"clear\"></div>\r\n\t\t\t\t</div>\r\n\t\t\t</div>\r\n\t\t\t<div id=\"footerBottom\">\r\n\t\t\t
+        \   <div class=\"container\">\r\n\t\t\t        <div id=\"footercontent\"><p>&copy;
+        <script type=\"text/javascript\">document.write(new Date().getFullYear());</script>
+        Cardiff Council</p></div>\r\n\t\t\t        <div class=\"clear\"></div>\r\n\t\t\t
+        \   </div>\r\n\t\t\t</div>\r\n        </div>    \r\n    </div>  \r\n    <!--
+        IDOX PA END -->           \r\n\t\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Mon, 15 Apr 2019 11:14:27 GMT
+- request:
+    method: get
+    uri: https://planningonline.cardiff.gov.uk/online-applications/applicationDetails.do?activeTab=relatedCases&keyVal=_CARDIFF_DCAPR_126566
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip,deflate,identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mechanize/2.7.6 Ruby/2.6.2p47 (http://github.com/sparklemotion/mechanize/)
+      Accept-Charset:
+      - ISO-8859-1,utf-8;q=0.7,*;q=0.7
+      Accept-Language:
+      - en-us,en;q=0.5
+      Cookie:
+      - JSESSIONID=ss9pKoHL32yHmhJQONSykek96zXCSSZ75skxJ5v1.vmidoxweblve; WSLang-CFC001=EN
+      Host:
+      - planningonline.cardiff.gov.uk
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '300'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - text/html; charset=UTF-8
+      Expires:
+      - Mon, 15 Apr 2019 11:15:00 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ua-Compatible:
+      - IE=edge
+      Server:
+      - Apache
+      Set-Cookie:
+      - WSLang-CFC001=EN; expires=Mon, 15-Apr-2069 11:14:58 GMT; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 15 Apr 2019 11:15:00 GMT
+      Content-Length:
+      - '19945'
+    body:
+      encoding: UTF-8
+      string: "\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n<!DOCTYPE
+        html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\r\n<html
+        lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\r\n<head>\r\n\t\r\n\t<!--
+        #BeginEditable \"doctitle\" -->\r\n    <title>\r\n    19/00309/MJR\r\n    |\r\n
+        \   \r\n        HEATING AND COOLING PLANT TO THE ROOF AND REAR COURTYARD\r\n
+        \       \r\n        |\r\n        \r\n    \r\n\r\n    \r\n\r\n    \r\n\r\n
+        \   \r\n    \r\n    \r\n    \r\n    \r\n        \r\n        23 WOMANBY STREET,
+        CITY CENTRE, CARDIFF, CF10 1BR\r\n    \r\n    \r\n    </title>\r\n<!-- #EndEditable
+        -->\r\n    <!-- #BeginEditable \"metatags\" --><!-- #EndEditable -->\r\n\t\r\n
+        \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
+        />\r\n\t\r\n\t<!-- Customer metatags -->\r\n\t\r\n\t\r\n\t<!-- Favicon link
+        -->\r\n    <link rel=\"icon\" href=\"/online-applications-skin/images/cardiff/favicon.ico\"
+        type=\"image/x-icon\" />\r\n\t\r\n    <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/screen.css\"
+        type=\"text/css\" media=\"screen,projection\" />\r\n    <link rel=\"stylesheet\"
+        href=\"/online-applications-skin/styles/theme1.css\" type=\"text/css\"/>    \r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/print.css\"
+        type=\"text/css\" media=\"print\" />\r\n\t\r\n    <script type=\"text/javascript\"
+        src=\"/online-applications-skin/scripts/jquery.min.js\"></script>\r\n    <script
+        type=\"text/javascript\" src=\"/online-applications-skin/scripts/jquery.toolbar.idox.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/common.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/checkbox.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/amplify.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/createCommentCookie.js\"></script>\r\n
+        \       \r\n\t<!-- Customer Analytics Script -->\r\n\t\r\n\t\r\n    <script
+        type=\"text/javascript\">\r\n    \t$('html').addClass('js');\r\n    \t$(document).ready(function(){\r\n
+        \   \t\t$('.main#apply>span:first-child').attr('tabindex', '0')\r\n    \t});\r\n
+        \   </script>\r\n    \r\n    <!-- #BeginEditable \"mobile\" --><!-- #EndEditable
+        -->\r\n    <!-- #BeginEditable \"head\" --><!-- #EndEditable -->\r\n    <!--
+        #BeginEditable \"webapp\" -->\r\n\t<script type=\"text/javascript\">\r\n\t
+        \   jQuery(document).ready(function() {\t\t\r\n\t\t\tjQuery('#pa').before('<img
+        src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\" id=\"preload\"
+        />');\r\n\t\t\tjQuery('#preload').hide();\r\n\t\t\tjQuery('.tabs a#tab_documents').click(
+        function(event) {\r\n\t\t\t\t  window.clearTimeout(window.timeOutId);\r\n\t\t\t\t
+        \ window.timeOutId = window.setTimeout(function() {\r\n\t\t\t\t\t\tjQuery('.content').before('<div
+        id=\"overlay\"></div><div id=\"loading\"><div id=\"message\">Loading. Please
+        wait.... <img src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\"
+        height=\"19\" width=\"220\" style=\"background:#fff;\" /></div></div>');\r\n\t\t\t\t
+        \ },10); \r\n\t\t\t\t});\r\n\t\t\t\t\r\n\t\t});\r\n\t</script>\r\n            \r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/simple_social_share.min.css\"
+        type=\"text/css\"/>\r\n    <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/simple_social_share.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\">\r\n        $(document).ready(function(){\r\n
+        \           \r\n            \r\n            $(\"share-button\").simpleSocialShare({\r\n
+        \               sites: \"twitter,email\", \r\n                url: window.location.href,
+        \r\n                title: \"Online application\", \r\n                description:
+        \"Please look at this Planning Application: \", \r\n                shareType:
+        \"button\", \r\n                buttonSide: \"left\", \r\n                orientation:
+        \"horizontal\"\r\n            });\r\n        });\r\n\t</script>\r\n\t<!--
+        #EndEditable -->\r\n\r\n</head>\r\n<body>\r\n\r\n    <a href=\"#pageheading\"
+        class=\"sr-only\">Skip to main content</a>\r\n\r\n    <!-- IDOX PA START -->\r\n
+        \   <div id=\"idox\">\r\n        <div id=\"pa\">\r\n\t\t\t<div id=\"header\"><!--
+        Selector: Selector 1 -->\r\n<style>\r\n#langStyle{float:right; margin-top:
+        10px; margin-right: 30px; background:transparent; font-size:13px; cursor:pointer;
+        border:1px solid #fff !important;border-radius:2px; z-index:999; background-color:
+        #fff; padding:2px;}\r\n#langStyle:hover{text-decoration: underline;}</style>\r\n<div>\r\n\r\n<!--CYS--><a
+        id=\"langStyle\" href=\"/online-applications/applicationDetails.do?activeTab=relatedCases&keyVal=_CARDIFF_DCAPR_126566&lang=CY\">Cymraeg</a><!--CYE-->\r\n</div>\r\n\t\t\t\t<div
+        class=\"container\">\r\n\t\t\t\t\t<div id=\"logo\"><a href=\"https://www.cardiff.gov.uk/\"
+        title=\"Cardiff Council home page\"><img src=\"/online-applications-skin/images/cardiff/logo.png\"
+        alt=\"Council logo\" /><span class=\"sr-only\">Cardiff Council</span></a></div>\r\n\t\t\t\t\t<div
+        id=\"headertitle\"><span></span></div>\r\n\t\t\t\t\t<div class=\"clear\"></div>\r\n\t\t\t\t</div>\t\r\n\t\t\t</div>\r\n\t\t\t<div
+        id=\"breadcrumbs\" class=\"container\">\r\n\t\t\t\t<ul>\r\n\t\t\t\t\t\r\n\t\t\t\t</ul>\r\n\t\t\t</div>\r\n
+        \           <div class=\"container\">\r\n       \t\t\t<div id=\"toolbar\"
+        class=\"nojs\">\r\n                    <ul>\t\r\n                        <li
+        id=\"search\" class=\"main\"><span tabindex=\"0\">Search&nbsp;</span><span
+        class=\"caret\"></span>\r\n   \t\t\t\t\t\t\t<ul>\t\r\n\t\t\t\t\t\t\t\t<!--
+        #BeginLibraryItem \"/Library/searchModulesNavItems.lbi\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \       \r\n            <li id=\"planLinks\">\r\n                <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\"
+        >\r\n                    <span>Planning</span>\r\n                </a>\r\n
+        \               <ul>\r\n                    <li id=\"planBasicSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\">\r\n
+        \                           Simple Search\r\n                        </a>\r\n
+        \                   </li>\r\n\r\n                    <li id=\"planAdvancedSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=advanced&amp;searchType=Application\">\r\n
+        \                           Advanced\r\n                        </a>\r\n                    </li>\r\n
+        \                   <li id=\"planListSearch\">\r\n                        <a
+        href=\"/online-applications/search.do?action=weeklyList&amp;searchType=Application\">\r\n
+        \                           Weekly/Monthly Lists\r\n                        </a>\r\n
+        \                   </li>\r\n                    <li id=\"planPropertySearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=property&amp;type=custom\">\r\n
+        \                           Property Search\r\n                        </a>\r\n
+        \                   </li>\r\n\t\t\t\t\t\r\n                    \r\n\t\t\t\t\t\r\n
+        \               </ul>\r\n            </li>\r\n        \r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        <!-- #EndLibraryItem -->\r\n                        \t</ul>\r\n\t\t\t\t\t\t</li>\r\n
+        \                       <!-- #BeginEditable \"applicationForms\" -->\n\n\n\n\n\n
+        \  \n<!-- #EndEditable -->   \t\t\t\t\r\n                        <li id=\"myprofile\"
+        class=\"main\"><span tabindex=\"0\">My Profile&nbsp;</span><span class=\"caret\"></span>\r\n
+        \                           <ul>\r\n                              <!-- #BeginLibraryItem
+        \"/Library/consulteeInTrayNavItem.lbi\" -->\n\n\n\n\n\n\n    <!-- #EndLibraryItem
+        -->\r\n                                <li><a href=\"/online-applications/registered/displayUserDetails.do\">Profile
+        Details</a></li>\r\n                                <li><a href=\"/online-applications/registered/savedSearch.do?action=display\">Saved
+        Searches</a></li>\r\n                                <li><a href=\"/online-applications/registered/userAdmin.do?action=showNotifiedApplications\">Notified
+        Applications</a></li>\r\n                                <li><a href=\"/online-applications/registered/trackedApplication.do?action=display\">Tracked
+        Applications</a></li>\r\n                                <!-- #BeginEditable
+        \"formSubmissions\" -->\n\n\n\n\n\n\n\n\n<!-- #EndEditable -->    \t\r\n                            </ul>\r\n
+        \                       </li>\r\n                        <li id=\"loginLink\"
+        class=\"main\"><!-- #BeginEditable \"loginlogout\" -->\n\n\n\n\n\n\n\n\n\n\n\t<a
+        href=\"/online-applications/registered/userAdmin.do\">Login</a>\n<!-- #EndEditable
+        --></li>\r\n                        <!-- #BeginEditable \"register\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \  \r\n\r\n\r\n\t<li id=\"register\">\r\n        <a href=\"/online-applications/registrationWizard.do?action=start\">Register</a>\r\n\t</li>\r\n\r\n<!--
+        #EndEditable -->\r\n                        <!-- #BeginLibraryItem \"/Library/applyOnlineNavItems.lbi\"
+        -->\r\n\r\n\r\n\r\n\r\n\r\n<!-- #EndLibraryItem -->\r\n                    </ul>\r\n
+        \   \t\t\t</div>\r\n\r\n    \t\t\t<!-- #BeginEditable \"headlinenews\" --><!--
+        #EndEditable -->\r\n                 \r\n                <div id=\"pageheading\">\r\n
+        \                   <h1><strong>Planning</strong>&nbsp;&ndash;&nbsp;<!-- #BeginEditable
+        \"pageheading\" -->Application Related Items<!-- #EndEditable --></h1>\r\n
+        \                   <!-- #BeginEditable \"helplink\" -->\r\n<p class=\"pagehelp\">\r\n\t<a
+        title=\"Help with this page (opens in a new window)\" rel=\"external\" target=\"_blank\"
+        href=\"/online-applications/help/pagehelp/applications.htm\">\r\n\t\tHelp
+        with this page\r\n\t<span> (opens in a new window)</span>\r\n\t</a>\r\n</p>\r\n<!--
+        #EndEditable -->\r\n                </div>\r\n                \r\n                <!--
+        START WAM CONTENT -->\r\n                <div class=\"content\">\r\n                    <!--
+        #BeginEditable \"errormsg\" --><!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"pagehead\" -->\r\n\r\n    <div class=\"addressCrumb\">\r\n
+        \       <span class=\"caseNumber\">\r\n            \r\n\r\n            \r\n
+        \               19/00309/MJR\r\n            \r\n        </span>\r\n\r\n        <span
+        class=\"divider1\">|</span>\r\n\r\n        \r\n            <span class=\"description\">\r\n
+        \               HEATING AND COOLING PLANT TO THE ROOF AND REAR COURTYARD\r\n
+        \           </span>\r\n            \r\n                <span class=\"divider2\">|</span>\r\n
+        \           \r\n        \r\n\r\n        \r\n\r\n        \r\n\r\n        \r\n
+        \       \r\n        \r\n        \r\n        \r\n            \r\n            <span
+        class=\"address\">\r\n                23 WOMANBY STREET, CITY CENTRE, CARDIFF,
+        CF10 1BR\r\n            </span>\r\n        \r\n        \r\n    </div>\r\n\r\n\r\n
+        \   <div id=\"applicationTools\">\r\n        <ul>\r\n            \r\n            \r\n
+        \               \r\n                    \r\n                        \r\n                            \r\n
+        \                           \r\n                                \r\n                                    <li>\r\n
+        \                                       <a href=\"/online-applications/searchResultsBack.do?action=back\"
+        id=\"searchresultsback\">Back to search results</a>\r\n                                    </li>\r\n
+        \                               \r\n                            \r\n                        \r\n
+        \                   \r\n                    \r\n                    \r\n                \r\n
+        \           \r\n\r\n            \r\n\r\n            \r\n            \r\n\r\n
+        \           \r\n\r\n            \r\n            \r\n                \r\n                    <li>\r\n
+        \                       <form name=\"trackForm\" method=\"post\" action=\"/online-applications/registered/trackedApplicationSubmit.do?action=track\"><input
+        type=\"hidden\" name=\"org.apache.struts.taglib.html.TOKEN\" value=\"7dc6dd6c4d1d2969f487576bd4aee86e\"
+        />\r\n                            <input type=\"hidden\" name=\"caseNo\" value=\"19/00309/MJR\"
+        />\r\n                            <input type=\"hidden\" name=\"caseType\"
+        value=\"Application\" />\r\n                            <input type=\"hidden\"
+        name=\"address\" value=\"23 WOMANBY STREET, CITY CENTRE, CARDIFF, CF10 1BR\"
+        />\r\n                            <input type=\"hidden\" name=\"description\"
+        value=\"HEATING AND COOLING PLANT TO THE ROOF AND REAR COURTYARD\" />\r\n
+        \                           <input type=\"hidden\" name=\"status\" value=\"Decided\"
+        />\r\n                            <input type=\"hidden\" name=\"trackingStatus\"
+        value=\"Decided\" />\r\n                            <input type=\"hidden\"
+        name=\"caseTechnicalKey\" value=\"_CARDIFF_DCAPR_126566\" />\r\n                            <input
+        class=\"casefiletrack\"\r\n                                   src=\"/online-applications-skin/images/button_track.gif\"\r\n
+        \                                  type=\"image\"\r\n                                   name=\"submit\"\r\n
+        \                                  altKey=\"casedetails.track\"\r\n                                   title=\"Get
+        informed when this item is updated\"/>\r\n                        </form>\r\n
+        \                   </li>\r\n                \r\n\r\n                \r\n
+        \           \r\n\r\n\r\n            \r\n                \r\n             \r\n
+        \           \r\n\r\n            \r\n            \r\n                \r\n            \r\n
+        \           \r\n            \r\n            <li>\r\n                <a href=\"/online-applications/applicationDetails.do?activeTab=printPreview&amp;keyVal=_CARDIFF_DCAPR_126566\"
+        id=\"print\" rel=\"external\">\r\n                    <img src=\"/online-applications-skin/images/button_print.gif\"
+        alt=\"Print summary icon\" width=\"53\" height=\"22\" border=\"0\"/>\r\n                </a>\r\n
+        \           </li>\r\n            \r\n\r\n            \r\n        </ul>\r\n\r\n
+        \   </div>\r\n\r\n\r\n     \r\n\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabs\" -->\r\n    \r\n    <ul class=\"tabs\">\r\n\r\n        \r\n\r\n
+        \           \r\n                \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/applicationDetails.do?activeTab=summary&amp;keyVal=_CARDIFF_DCAPR_126566\"
+        id=\"tab_summary\">\r\n                        <span>\r\n                            Details\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n                \r\n
+        \               <li>\r\n\r\n                     \r\n                    <a
+        href=\"/online-applications/applicationDetails.do?activeTab=makeComment&amp;keyVal=_CARDIFF_DCAPR_126566\"
+        id=\"tab_makeComment\">\r\n                        <span>\r\n                            Comments\r\n
+        \                           \r\n                                \r\n                                (0)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n\r\n
+        \           \r\n                <li class=\"nodocuments\">\r\n                    <span>\r\n
+        \                       Constraints\r\n                        \r\n                            \r\n
+        \                           (0)\r\n                        \r\n                    </span>\r\n
+        \               </li>\r\n            \r\n\r\n        \r\n\r\n            \r\n
+        \               \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/applicationDetails.do?activeTab=documents&amp;keyVal=_CARDIFF_DCAPR_126566\"
+        id=\"tab_documents\">\r\n                        <span>\r\n                            Documents\r\n
+        \                           \r\n                                \r\n                                (11)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n                \r\n
+        \               <li>\r\n\r\n                     \r\n                    <a
+        href=\"/online-applications/applicationDetails.do?activeTab=relatedCases&amp;keyVal=_CARDIFF_DCAPR_126566\"
+        id=\"tab_relatedCases\" class=\"active\">\r\n                        <span>\r\n
+        \                           Related Cases\r\n                            \r\n
+        \                               \r\n                                (1)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                        \r\n
+        \                       \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n\r\n
+        \           \r\n\r\n        \r\n    </ul>\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabsubnav\" --><!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"pagebody\" -->\r\n\r\n    \r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \   <div class=\"tabcontainer toplevel\">\r\n    <div id=\"relatedItems\">\r\n\r\n
+        \       \r\n            \r\n            \r\n\r\n            <!-- Display header
+        -->\r\n            <div id=\"Application\">\r\n                <h3>\r\n                    \r\n
+        \                   \r\n                        Planning Applications\r\n
+        \                   \r\n                    <span>(0)</span>\r\n                </h3>\n\r\n\r\n
+        \               <!-- Display each item -->\r\n                \r\n            </div>\r\n\r\n
+        \       \r\n            \r\n            \r\n\r\n            <!-- Display header
+        -->\r\n            <div id=\"Appeal\">\r\n                <h3>\r\n                    \r\n
+        \                   \r\n                        Planning Appeals\r\n                    \r\n
+        \                   <span>(0)</span>\r\n                </h3>\n\r\n\r\n                <!--
+        Display each item -->\r\n                \r\n            </div>\r\n\r\n        \r\n
+        \           \r\n            \r\n\r\n            <!-- Display header -->\r\n
+        \           <div id=\"Enforcement\">\r\n                <h3>\r\n                    \r\n
+        \                   \r\n                        Planning Enforcements\r\n
+        \                   \r\n                    <span>(0)</span>\r\n                </h3>\n\r\n\r\n
+        \               <!-- Display each item -->\r\n                \r\n            </div>\r\n\r\n
+        \       \r\n            \r\n            \r\n\r\n            <!-- Display header
+        -->\r\n            <div id=\"Property\">\r\n                <h3>\r\n                    \r\n
+        \                   \r\n                        Properties\r\n                    \r\n
+        \                   <span>(1)</span>\r\n                </h3>\n\r\n\r\n                <!--
+        Display each item -->\r\n                \r\n                    <ul>\r\n
+        \                       \r\n                            <li>\r\n                                \r\n
+        \                               \r\n                                \r\n\r\n
+        \                               <a href=\"/online-applications/propertyDetails.do?previousCaseType=Application&amp;keyVal=_CARDIFF_PROPLPI_17986_1&amp;previousCaseNumber=19%2F00309%2FMJR&amp;activeTab=summary&amp;previousKeyVal=_CARDIFF_DCAPR_126566\">\r\n
+        \                                   23 WOMANBY STREET, CITY CENTRE, CARDIFF,
+        CF10 1BR\r\n                                </a>\r\n\r\n                                <p
+        class=\"metaInfo\">\r\n\r\n                                \r\n\r\n                                \r\n\r\n
+        \                               \r\n                                \r\n                                \r\n
+        \                              </p>\r\n                            </li>\r\n
+        \                       \r\n                    </ul>\r\n                \r\n
+        \           </div>\r\n\r\n        \r\n\r\n    </div>\r\n    </div>\r\n\r\n<!--
+        #EndEditable -->\r\n                    <!-- #BeginEditable \"pagefoot\" --><!--
+        #EndEditable -->\r\n                </div>\r\n                <!-- END WAM
+        CONTENT -->\r\n                \r\n                <p id=\"poweredBy\"><a
+        href=\"http://www.idoxgroup.com/\" target=\"_blank\" title=\"This link will
+        open a new window\"><img src=\"/online-applications-skin/images/idox.gif\"
+        alt=\"an Idox solution\" /></a></p>\r\n            </div>\t\r\n\t\t\t<div
+        id=\"footer\">\r\n\t\t\t\t<div class=\"container\">\t\t\t\t\t\r\n\t\t\t\t\t<div
+        id=\"links\">\r\n\t\t\t\t\t\t<ul>\r\n\t\t\t\t\t\t\t<li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Site_Map/Pages/default.aspx\">Site
+        map</a></li><li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Cookies/Pages/Cookies.aspx\">Cookies</a></li><li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/New_Disclaimer/Pages/default.aspx\">Disclaimer</a></li>\r\n\t\t\t\t\t\t</ul>\r\n\t\t\t\t\t</div>\r\n\t\t\t\t\t<div
+        class=\"clear\"></div>\r\n\t\t\t\t</div>\r\n\t\t\t</div>\r\n\t\t\t<div id=\"footerBottom\">\r\n\t\t\t
+        \   <div class=\"container\">\r\n\t\t\t        <div id=\"footercontent\"><p>&copy;
+        <script type=\"text/javascript\">document.write(new Date().getFullYear());</script>
+        Cardiff Council</p></div>\r\n\t\t\t        <div class=\"clear\"></div>\r\n\t\t\t
+        \   </div>\r\n\t\t\t</div>\r\n        </div>    \r\n    </div>  \r\n    <!--
+        IDOX PA END -->           \r\n\t\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Mon, 15 Apr 2019 11:14:29 GMT
+- request:
+    method: get
+    uri: https://planningonline.cardiff.gov.uk/online-applications/propertyDetails.do?activeTab=summary&keyVal=_CARDIFF_PROPLPI_17986_1&previousCaseNumber=19/00309/MJR&previousCaseType=Application&previousKeyVal=_CARDIFF_DCAPR_126566
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip,deflate,identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mechanize/2.7.6 Ruby/2.6.2p47 (http://github.com/sparklemotion/mechanize/)
+      Accept-Charset:
+      - ISO-8859-1,utf-8;q=0.7,*;q=0.7
+      Accept-Language:
+      - en-us,en;q=0.5
+      Cookie:
+      - JSESSIONID=ss9pKoHL32yHmhJQONSykek96zXCSSZ75skxJ5v1.vmidoxweblve; WSLang-CFC001=EN
+      Host:
+      - planningonline.cardiff.gov.uk
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '300'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - text/html; charset=UTF-8
+      Expires:
+      - Mon, 15 Apr 2019 11:15:02 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ua-Compatible:
+      - IE=edge
+      Server:
+      - Apache
+      Set-Cookie:
+      - WSLang-CFC001=EN; expires=Mon, 15-Apr-2069 11:15:00 GMT; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 15 Apr 2019 11:15:01 GMT
+      Content-Length:
+      - '13516'
+    body:
+      encoding: UTF-8
+      string: "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n    \n\n    \n\n<!DOCTYPE html PUBLIC
+        \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\r\n<html
+        lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\r\n<head>\r\n\r\n\t<!--
+        #BeginEditable \"doctitle\" -->\r\n    <title>\r\n    _CARDIFF_PROPLPI_17986_1\r\n
+        \   |\r\n    \r\n\r\n    \r\n\r\n    \r\n\r\n    \r\n    \r\n    \r\n    \r\n
+        \   \r\n        \r\n        23 WOMANBY STREET, CITY CENTRE, CARDIFF, CF10
+        1BR\r\n    \r\n    \r\n    </title>\r\n<!-- #EndEditable -->\r\n    <!-- #BeginEditable
+        \"metatags\" --><!-- #EndEditable -->\r\n\t\r\n    <meta http-equiv=\"Content-Type\"
+        content=\"text/html; charset=UTF-8\" />\r\n\t\r\n\t<!-- Customer metatags
+        -->\r\n\t\r\n\t\r\n\t<!-- Favicon link -->\r\n    <link rel=\"icon\" href=\"/online-applications-skin/images/cardiff/favicon.ico\"
+        type=\"image/x-icon\" />\r\n\t\r\n    <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/screen.css\"
+        type=\"text/css\" media=\"screen,projection\" />\r\n    <link rel=\"stylesheet\"
+        href=\"/online-applications-skin/styles/theme1.css\" type=\"text/css\"/>\t\r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/print.css\"
+        type=\"text/css\" media=\"print\" />   \r\n\r\n    <script type=\"text/javascript\"
+        src=\"/online-applications-skin/scripts/jquery.min.js\"></script>\r\n    <script
+        type=\"text/javascript\" src=\"/online-applications-skin/scripts/jquery.toolbar.idox.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/common.js\"></script>\r\n
+        \       \r\n\t<!-- Customer Analytics Script -->\r\n\t\r\n\t\r\n    <script
+        type=\"text/javascript\">\r\n    \t$('html').addClass('js');\r\n    \t$(document).ready(function(){\r\n
+        \   \t\t$('.main#apply>span:first-child').attr('tabindex', '0')\r\n    \t});\r\n
+        \   </script>\r\n    \r\n    <!-- #BeginEditable \"mobile\" --><!-- #EndEditable
+        -->\r\n    <!-- #BeginEditable \"head\" --><!-- #EndEditable -->\r\n    <!--
+        #BeginEditable \"webapp\" --><!-- #EndEditable -->\r\n\r\n</head>\r\n<body>\r\n\r\n
+        \   <a href=\"#pageheading\" class=\"sr-only\">Skip to main content</a>\r\n\r\n
+        \   <!-- IDOX PA START -->\r\n    <div id=\"idox\">\r\n        <div id=\"pa\">
+        \r\n\t\t\t<div id=\"header\"><!-- Selector: Selector 1 -->\r\n<style>\r\n#langStyle{float:right;
+        margin-top: 10px; margin-right: 30px; background:transparent; font-size:13px;
+        cursor:pointer; border:1px solid #fff !important;border-radius:2px; z-index:999;
+        background-color: #fff; padding:2px;}\r\n#langStyle:hover{text-decoration:
+        underline;}</style>\r\n<div>\r\n\r\n<!--CYS--><a id=\"langStyle\" href=\"/online-applications/propertyDetails.do?previousCaseType=Application&keyVal=_CARDIFF_PROPLPI_17986_1&previousCaseNumber=19%2f00309%2fMJR&activeTab=summary&previousKeyVal=_CARDIFF_DCAPR_126566&lang=CY\">Cymraeg</a><!--CYE-->\r\n</div>\r\n\t\t\t\t<div
+        class=\"container\">\r\n\t\t\t\t\t<div id=\"logo\"><a href=\"https://www.cardiff.gov.uk/\"
+        title=\"Cardiff Council home page\"><img src=\"/online-applications-skin/images/cardiff/logo.png\"
+        alt=\"Council logo\" /><span class=\"sr-only\">Cardiff Council</span></a></div>\r\n\t\t\t\t\t<div
+        id=\"headertitle\"><span></span></div>\r\n\t\t\t\t\t<div class=\"clear\"></div>\r\n\t\t\t\t</div>\t\r\n\t\t\t</div>\r\n\t\t\t<div
+        id=\"breadcrumbs\" class=\"container\">\r\n\t\t\t\t<ul>\r\n\t\t\t\t\t\r\n\t\t\t\t</ul>\r\n\t\t\t</div>\r\n
+        \           <div class=\"container\">\r\n                <div id=\"toolbar\"
+        class=\"nojs\">\r\n                    <ul>\t\r\n                        <li
+        id=\"search\" class=\"main\"><span tabindex=\"0\">Search&nbsp;</span><span
+        class=\"caret\"></span>\r\n   \t\t\t\t\t\t\t<ul>\t\r\n\t\t\t\t\t\t\t\t<!--
+        #BeginLibraryItem \"/Library/searchModulesNavItems.lbi\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \       \r\n            <li id=\"planLinks\">\r\n                <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\"
+        >\r\n                    <span>Planning</span>\r\n                </a>\r\n
+        \               <ul>\r\n                    <li id=\"planBasicSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\">\r\n
+        \                           Simple Search\r\n                        </a>\r\n
+        \                   </li>\r\n\r\n                    <li id=\"planAdvancedSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=advanced&amp;searchType=Application\">\r\n
+        \                           Advanced\r\n                        </a>\r\n                    </li>\r\n
+        \                   <li id=\"planListSearch\">\r\n                        <a
+        href=\"/online-applications/search.do?action=weeklyList&amp;searchType=Application\">\r\n
+        \                           Weekly/Monthly Lists\r\n                        </a>\r\n
+        \                   </li>\r\n                    <li id=\"planPropertySearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=property&amp;type=custom\">\r\n
+        \                           Property Search\r\n                        </a>\r\n
+        \                   </li>\r\n\t\t\t\t\t\r\n                    \r\n\t\t\t\t\t\r\n
+        \               </ul>\r\n            </li>\r\n        \r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        <!-- #EndLibraryItem -->\r\n                        \t</ul>\r\n\t\t\t\t\t\t</li>\r\n
+        \                       <!-- #BeginEditable \"applicationForms\" -->\n\n\n\n\n\n
+        \  \n<!-- #EndEditable -->   \t\t\t\t\r\n                        <li id=\"myprofile\"
+        class=\"main\"><span tabindex=\"0\">My Profile&nbsp;</span><span class=\"caret\"></span>\r\n
+        \                           <ul>\r\n                              <!-- #BeginLibraryItem
+        \"/Library/consulteeInTrayNavItem.lbi\" -->\n\n\n\n\n\n\n    <!-- #EndLibraryItem
+        -->\r\n                                <li><a href=\"/online-applications/registered/displayUserDetails.do\">Profile
+        Details</a></li>\r\n                                <li><a href=\"/online-applications/registered/savedSearch.do?action=display\">Saved
+        Searches</a></li>\r\n                                <li><a href=\"/online-applications/registered/userAdmin.do?action=showNotifiedApplications\">Notified
+        Applications</a></li>\r\n                                <li><a href=\"/online-applications/registered/trackedApplication.do?action=display\">Tracked
+        Applications</a></li>\r\n                                <!-- #BeginEditable
+        \"formSubmissions\" -->\n\n\n\n\n\n\n\n\n<!-- #EndEditable -->    \t\r\n                            </ul>\r\n
+        \                       </li>\r\n                        <li id=\"loginLink\"
+        class=\"main\"><!-- #BeginEditable \"loginlogout\" -->\n\n\n\n\n\n\n\n\n\n\n\t<a
+        href=\"/online-applications/registered/userAdmin.do\">Login</a>\n<!-- #EndEditable
+        --></li>\r\n                        <!-- #BeginEditable \"register\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \  \r\n\r\n\r\n\t<li id=\"register\">\r\n        <a href=\"/online-applications/registrationWizard.do?action=start\">Register</a>\r\n\t</li>\r\n\r\n<!--
+        #EndEditable -->\r\n                        <!-- #BeginLibraryItem \"/Library/applyOnlineNavItems.lbi\"
+        -->\r\n\r\n\r\n\r\n\r\n\r\n<!-- #EndLibraryItem -->\r\n                    </ul>\r\n
+        \   \t\t\t</div>\r\n                \r\n                <div id=\"pageheading\">\r\n
+        \                   <h1><!-- #BeginEditable \"pageheading\" -->Property Address<!--
+        #EndEditable --></h1>\r\n                    <!-- #BeginEditable \"helplink\"
+        -->\r\n<p class=\"pagehelp\">\r\n\t<a title=\"Help with this page (opens in
+        a new window)\" rel=\"external\" target=\"_blank\" href=\"/online-applications/help/pagehelp/properties.htm\">\r\n\t\tHelp
+        with this page\r\n\t<span> (opens in a new window)</span>\r\n\t</a>\r\n</p>\r\n<!--
+        #EndEditable -->\r\n                </div>\r\n        \r\n                <!--
+        START WAM CONTENT -->\r\n                <div class=\"content\">\r\n                    <!--
+        #BeginEditable \"errormsg\" -->\n        \n        \n\n        \n        \n
+        \   <!-- #EndEditable -->\r\n                    <!-- #BeginEditable \"pagehead\"
+        -->\r\n\r\n    <div class=\"addressCrumb\">\r\n        <span class=\"caseNumber\">\r\n
+        \           \r\n                100100890011 \r\n            \r\n\r\n            \r\n
+        \       </span>\r\n\r\n        <span class=\"divider1\">|</span>\r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        \r\n\r\n        \r\n        \r\n        \r\n        \r\n
+        \       \r\n            \r\n            <span class=\"address\">\r\n                23
+        WOMANBY STREET, CITY CENTRE, CARDIFF, CF10 1BR\r\n            </span>\r\n
+        \       \r\n        \r\n    </div>\r\n\r\n\r\n    <div id=\"applicationTools\">\r\n
+        \       <ul>\r\n            \r\n            \r\n\r\n            \r\n\r\n            \r\n
+        \           \r\n                <li>\r\n                    <a href=\"/online-applications/applicationDetails.do?keyVal=_CARDIFF_DCAPR_126566&amp;activeTab=summary\"
+        id=\"searchresultsback\">\r\n                        Planning Application\r\n
+        \                       \r\n                        \r\n                            19/00309/MJR\r\n
+        \                       \r\n                    </a>\r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n            \r\n            \r\n\r\n\r\n
+        \           \r\n                \r\n             \r\n            \r\n\r\n
+        \           \r\n            \r\n                \r\n            \r\n            \r\n
+        \           \r\n            <li>\r\n                <a href=\"/online-applications/propertyDetails.do?activeTab=printPreview&amp;keyVal=_CARDIFF_PROPLPI_17986_1\"
+        id=\"print\" rel=\"external\">\r\n                    <img src=\"/online-applications-skin/images/button_print.gif\"
+        alt=\"Print summary icon\" width=\"53\" height=\"22\" border=\"0\"/>\r\n                </a>\r\n
+        \           </li>\r\n            \r\n\r\n            \r\n        </ul>\r\n\r\n
+        \   </div>\r\n\r\n\r\n     \r\n\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabs\" -->\r\n    \r\n    <ul class=\"tabs\">\r\n\r\n        \r\n\r\n
+        \           \r\n                \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/propertyDetails.do?activeTab=summary&amp;keyVal=_CARDIFF_PROPLPI_17986_1\"
+        id=\"tab_summary\" class=\"active\">\r\n                        <span>\r\n
+        \                           Address\r\n                            \r\n                        </span>\r\n
+        \                   </a>\r\n\r\n                    \r\n                    \r\n
+        \                   \r\n                        \r\n                        \r\n
+        \                   \r\n                </li>\r\n            \r\n\r\n            \r\n\r\n
+        \       \r\n\r\n            \r\n                \r\n                <li>\r\n\r\n
+        \                    \r\n                    <a href=\"/online-applications/propertyDetails.do?activeTab=relatedCases&amp;keyVal=_CARDIFF_PROPLPI_17986_1\"
+        id=\"tab_relatedCases\">\r\n                        <span>\r\n                            Property
+        History\r\n                            \r\n                                \r\n
+        \                               (3)\r\n                            \r\n                        </span>\r\n
+        \                   </a>\r\n\r\n                    \r\n                    \r\n
+        \                   \r\n                </li>\r\n            \r\n\r\n            \r\n\r\n
+        \       \r\n\r\n            \r\n                \r\n                <li>\r\n\r\n
+        \                    \r\n                    <a href=\"/online-applications/propertyDetails.do?activeTab=constraints&amp;keyVal=_CARDIFF_PROPLPI_17986_1\"
+        id=\"tab_constraints\">\r\n                        <span>\r\n                            Constraints\r\n
+        \                           \r\n                                \r\n                                (1)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n\r\n
+        \           \r\n\r\n        \r\n    </ul>\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabsubnav\" --><!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"pagebody\" -->\n    \r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\n
+        \   \n        \n        \n    \n\n    \n    \n    \n    \n    \n        \n
+        \       \n    \n\n    <div class=\"tabcontainer toplevel\">\n\n        \n
+        \       \n        \n            \n            <table id=\"propertyAddress\"
+        summary=\"Property address\">\r\n<tr class=\"row0\">\r\n<th scope=\"row\">UPRN:</th>\r\n<td>100100890011</td>\r\n</tr>\r\n<tr
+        class=\"row1\">\r\n<th scope=\"row\">Full Address:</th>\r\n<td>23 WOMANBY
+        STREET, CITY CENTRE, CARDIFF, CF10 1BR</td>\r\n</tr>\r\n<tr class=\"row1\">\r\n<th
+        scope=\"row\">Property Number:</th>\r\n<td>23</td>\r\n</tr>\r\n<tr class=\"row0\">\r\n<th
+        scope=\"row\">Street:</th>\r\n<td>WOMANBY STREET</td>\r\n</tr>\r\n<tr class=\"row1\">\r\n<th
+        scope=\"row\">Town:</th>\r\n<td>CARDIFF</td>\r\n</tr>\r\n<tr class=\"row0\">\r\n<th
+        scope=\"row\">Postcode:</th>\r\n<td>CF10 1BR</td>\r\n</tr>\r\n<tr class=\"row1\">\r\n<th
+        scope=\"row\">Ward:</th>\r\n<td>CATHAYS</td>\r\n</tr>\r\n<tr class=\"row0\">\r\n<th
+        scope=\"row\">Parish:</th>\r\n<td/>\r\n</tr>\r\n</table>\r\n\n        \n\n
+        \       \n        \n\n        \n        \n            \n        \n\n    </div>\n<!--
+        #EndEditable -->\r\n                    <!-- #BeginEditable \"pagefoot\" --><!--
+        #EndEditable -->\r\n                </div>\r\n                <!-- END WAM
+        CONTENT -->\r\n                \r\n                <p id=\"poweredBy\"><a
+        href=\"http://www.idoxgroup.com/\" target=\"_blank\" title=\"This link will
+        open a new window\"><img src=\"/online-applications-skin/images/idox.gif\"
+        alt=\"an Idox solution\" /></a></p>\r\n            </div>\r\n\t\t\t<div id=\"footer\">\r\n\t\t\t\t<div
+        class=\"container\">\t\t\t\t\t\r\n\t\t\t\t\t<div id=\"links\">\r\n\t\t\t\t\t\t<ul>\r\n\t\t\t\t\t\t\t<li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/Site_Map/Pages/default.aspx\">Site
+        map</a></li><li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Cookies/Pages/Cookies.aspx\">Cookies</a></li><li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/New_Disclaimer/Pages/default.aspx\">Disclaimer</a></li>\r\n\t\t\t\t\t\t</ul>\r\n\t\t\t\t\t</div>\r\n\t\t\t\t\t<div
+        class=\"clear\"></div>\r\n\t\t\t\t</div>\r\n\t\t\t</div>\r\n\t\t\t<div id=\"footerBottom\">\r\n\t\t\t
+        \   <div class=\"container\">\r\n\t\t\t        <div id=\"footercontent\"><p>&copy;
+        <script type=\"text/javascript\">document.write(new Date().getFullYear());</script>
+        Cardiff Council</p></div>\r\n\t\t\t        <div class=\"clear\"></div>\r\n\t\t\t
+        \   </div>\r\n\t\t\t</div>\r\n        </div>\r\n    </div>\r\n    <!-- IDOX
+        PA END -->\r\n\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Mon, 15 Apr 2019 11:14:30 GMT
+- request:
+    method: get
+    uri: https://planningonline.cardiff.gov.uk/online-applications/applicationDetails.do?activeTab=summary&keyVal=_CARDIFF_DCAPR_126537
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip,deflate,identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mechanize/2.7.6 Ruby/2.6.2p47 (http://github.com/sparklemotion/mechanize/)
+      Accept-Charset:
+      - ISO-8859-1,utf-8;q=0.7,*;q=0.7
+      Accept-Language:
+      - en-us,en;q=0.5
+      Cookie:
+      - JSESSIONID=ss9pKoHL32yHmhJQONSykek96zXCSSZ75skxJ5v1.vmidoxweblve; WSLang-CFC001=EN
+      Host:
+      - planningonline.cardiff.gov.uk
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '300'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - text/html; charset=UTF-8
+      Expires:
+      - Mon, 15 Apr 2019 11:15:16 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ua-Compatible:
+      - IE=edge
+      Server:
+      - Apache
+      Set-Cookie:
+      - WSLang-CFC001=EN; expires=Mon, 15-Apr-2069 11:15:12 GMT; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 15 Apr 2019 11:15:16 GMT
+      Content-Length:
+      - '28293'
+    body:
+      encoding: UTF-8
+      string: "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n    \n\n    \n\n<!DOCTYPE html PUBLIC
+        \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\r\n<html
+        lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\r\n<head>\r\n\t\r\n\t<!--
+        #BeginEditable \"doctitle\" -->\r\n    <title>\r\n    19/00284/DCH\r\n    |\r\n
+        \   \r\n        1ST FLOOR REAR AND GROUND FLOOR SIDE EXTENSION\r\n        \r\n
+        \       |\r\n        \r\n    \r\n\r\n    \r\n\r\n    \r\n\r\n    \r\n    \r\n
+        \   \r\n    \r\n    \r\n        \r\n        3 RHYD Y PENAU ROAD, CYNCOED,
+        CARDIFF, CF23 6PX\r\n    \r\n    \r\n    </title>\r\n<!-- #EndEditable -->\r\n
+        \   <!-- #BeginEditable \"metatags\" --><!-- #EndEditable -->\r\n\t\r\n    <meta
+        http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" />\r\n\t\r\n\t<!--
+        Customer metatags -->\r\n\t\r\n\t\r\n\t<!-- Favicon link -->\r\n    <link
+        rel=\"icon\" href=\"/online-applications-skin/images/cardiff/favicon.ico\"
+        type=\"image/x-icon\" />\r\n\t\r\n    <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/screen.css\"
+        type=\"text/css\" media=\"screen,projection\" />\r\n    <link rel=\"stylesheet\"
+        href=\"/online-applications-skin/styles/theme1.css\" type=\"text/css\"/>    \r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/print.css\"
+        type=\"text/css\" media=\"print\" />\r\n\t\r\n    <script type=\"text/javascript\"
+        src=\"/online-applications-skin/scripts/jquery.min.js\"></script>\r\n    <script
+        type=\"text/javascript\" src=\"/online-applications-skin/scripts/jquery.toolbar.idox.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/common.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/checkbox.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/amplify.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/createCommentCookie.js\"></script>\r\n
+        \       \r\n\t<!-- Customer Analytics Script -->\r\n\t\r\n\t\r\n    <script
+        type=\"text/javascript\">\r\n    \t$('html').addClass('js');\r\n    \t$(document).ready(function(){\r\n
+        \   \t\t$('.main#apply>span:first-child').attr('tabindex', '0')\r\n    \t});\r\n
+        \   </script>\r\n    \r\n    <!-- #BeginEditable \"mobile\" --><!-- #EndEditable
+        -->\r\n    <!-- #BeginEditable \"head\" -->\r\n\t<script type=\"text/javascript\">\r\n\t
+        \   jQuery(document).ready(function() {\t\r\n\t\t\tjQuery('#pa').before('<img
+        src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\" id=\"preload\"
+        />');\r\n\t\t\tjQuery('#preload').hide();\r\n\t\t\tjQuery('.tabs a#tab_documents').click(
+        function(event) {\r\n\t\t\t\t  window.clearTimeout(window.timeOutId);\r\n\t\t\t\t
+        \ window.timeOutId = window.setTimeout(function() {\r\n\t\t\t\t\t\tjQuery('.content').before('<div
+        id=\"overlay\"></div><div id=\"loading\"><div id=\"message\">Loading. Please
+        wait.... <img src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\"
+        height=\"19\" width=\"220\" style=\"background:#fff;\" /></div></div>');\r\n\t\t\t\t
+        \ },10);\r\n\t\t\t\t});\r\n\t\t\tjQuery('p.associateddocument a').click( function(event)
+        {\r\n\t\t\t\t  window.clearTimeout(window.timeOutId);\r\n\t\t\t\t  window.timeOutId
+        = window.setTimeout(function() {\r\n\t\t\t\t\t\tjQuery('.content').before('<div
+        id=\"overlay\"></div><div id=\"loading\"><div id=\"message\">Loading. Please
+        wait.... <img src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\"
+        height=\"19\" width=\"220\" style=\"background:#fff;\" /></div></div>');\r\n\t\t\t\t
+        \ },10);\r\n\t\t\t\t});\r\n\r\n\t\t});\r\n    </script>\r\n    \r\n    <link
+        rel=\"stylesheet\" href=\"/online-applications-skin/styles/simple_social_share.min.css\"
+        type=\"text/css\"/>\r\n    <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/simple_social_share.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\">\r\n        $(document).ready(function(){\r\n
+        \           \r\n            \r\n            $(\"share-button\").simpleSocialShare({\r\n
+        \               sites: \"twitter,email\", \r\n                url: window.location.href,
+        \r\n                title: \"Online application\", \r\n                description:
+        \"Please look at this Planning Application: \", \r\n                shareType:
+        \"button\", \r\n                buttonSide: \"left\", \r\n                orientation:
+        \"horizontal\"\r\n            });\r\n        });\r\n\t</script>\r\n\t<!--
+        #EndEditable -->\r\n    <!-- #BeginEditable \"webapp\" --><!-- #EndEditable
+        -->\r\n\r\n</head>\r\n<body>\r\n\r\n    <a href=\"#pageheading\" class=\"sr-only\">Skip
+        to main content</a>\r\n\r\n    <!-- IDOX PA START -->\r\n    <div id=\"idox\">\r\n
+        \       <div id=\"pa\">\r\n\t\t\t<div id=\"header\"><!-- Selector: Selector
+        1 -->\r\n<style>\r\n#langStyle{float:right; margin-top: 10px; margin-right:
+        30px; background:transparent; font-size:13px; cursor:pointer; border:1px solid
+        #fff !important;border-radius:2px; z-index:999; background-color: #fff; padding:2px;}\r\n#langStyle:hover{text-decoration:
+        underline;}</style>\r\n<div>\r\n\r\n<!--CYS--><a id=\"langStyle\" href=\"/online-applications/applicationDetails.do?keyVal=_CARDIFF_DCAPR_126537&activeTab=summary&lang=CY\">Cymraeg</a><!--CYE-->\r\n</div>\r\n\t\t\t\t<div
+        class=\"container\">\r\n\t\t\t\t\t<div id=\"logo\"><a href=\"https://www.cardiff.gov.uk/\"
+        title=\"Cardiff Council home page\"><img src=\"/online-applications-skin/images/cardiff/logo.png\"
+        alt=\"Council logo\" /><span class=\"sr-only\">Cardiff Council</span></a></div>\r\n\t\t\t\t\t<div
+        id=\"headertitle\"><span></span></div>\r\n\t\t\t\t\t<div class=\"clear\"></div>\r\n\t\t\t\t</div>\t\r\n\t\t\t</div>\r\n\t\t\t<div
+        id=\"breadcrumbs\" class=\"container\">\r\n\t\t\t\t<ul>\r\n\t\t\t\t\t\r\n\t\t\t\t</ul>\r\n\t\t\t</div>\r\n
+        \           <div class=\"container\">\r\n       \t\t\t<div id=\"toolbar\"
+        class=\"nojs\">\r\n                    <ul>\t\r\n                        <li
+        id=\"search\" class=\"main\"><span tabindex=\"0\">Search&nbsp;</span><span
+        class=\"caret\"></span>\r\n   \t\t\t\t\t\t\t<ul>\t\r\n\t\t\t\t\t\t\t\t<!--
+        #BeginLibraryItem \"/Library/searchModulesNavItems.lbi\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \       \r\n            <li id=\"planLinks\">\r\n                <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\"
+        >\r\n                    <span>Planning</span>\r\n                </a>\r\n
+        \               <ul>\r\n                    <li id=\"planBasicSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\">\r\n
+        \                           Simple Search\r\n                        </a>\r\n
+        \                   </li>\r\n\r\n                    <li id=\"planAdvancedSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=advanced&amp;searchType=Application\">\r\n
+        \                           Advanced\r\n                        </a>\r\n                    </li>\r\n
+        \                   <li id=\"planListSearch\">\r\n                        <a
+        href=\"/online-applications/search.do?action=weeklyList&amp;searchType=Application\">\r\n
+        \                           Weekly/Monthly Lists\r\n                        </a>\r\n
+        \                   </li>\r\n                    <li id=\"planPropertySearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=property&amp;type=custom\">\r\n
+        \                           Property Search\r\n                        </a>\r\n
+        \                   </li>\r\n\t\t\t\t\t\r\n                    \r\n\t\t\t\t\t\r\n
+        \               </ul>\r\n            </li>\r\n        \r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        <!-- #EndLibraryItem -->\r\n                        \t</ul>\r\n\t\t\t\t\t\t</li>\r\n
+        \                       <!-- #BeginEditable \"applicationForms\" -->\n\n\n\n\n\n
+        \  \n<!-- #EndEditable -->   \t\t\t\t\r\n                        <li id=\"myprofile\"
+        class=\"main\"><span tabindex=\"0\">My Profile&nbsp;</span><span class=\"caret\"></span>\r\n
+        \                           <ul>\r\n                              <!-- #BeginLibraryItem
+        \"/Library/consulteeInTrayNavItem.lbi\" -->\n\n\n\n\n\n\n    <!-- #EndLibraryItem
+        -->\r\n                                <li><a href=\"/online-applications/registered/displayUserDetails.do\">Profile
+        Details</a></li>\r\n                                <li><a href=\"/online-applications/registered/savedSearch.do?action=display\">Saved
+        Searches</a></li>\r\n                                <li><a href=\"/online-applications/registered/userAdmin.do?action=showNotifiedApplications\">Notified
+        Applications</a></li>\r\n                                <li><a href=\"/online-applications/registered/trackedApplication.do?action=display\">Tracked
+        Applications</a></li>\r\n                                <!-- #BeginEditable
+        \"formSubmissions\" -->\n\n\n\n\n\n\n\n\n<!-- #EndEditable -->    \t\r\n                            </ul>\r\n
+        \                       </li>\r\n                        <li id=\"loginLink\"
+        class=\"main\"><!-- #BeginEditable \"loginlogout\" -->\n\n\n\n\n\n\n\n\n\n\n\t<a
+        href=\"/online-applications/registered/userAdmin.do\">Login</a>\n<!-- #EndEditable
+        --></li>\r\n                        <!-- #BeginEditable \"register\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \  \r\n\r\n\r\n\t<li id=\"register\">\r\n        <a href=\"/online-applications/registrationWizard.do?action=start\">Register</a>\r\n\t</li>\r\n\r\n<!--
+        #EndEditable -->\r\n                        <!-- #BeginLibraryItem \"/Library/applyOnlineNavItems.lbi\"
+        -->\r\n\r\n\r\n\r\n\r\n\r\n<!-- #EndLibraryItem -->\r\n                    </ul>\r\n
+        \   \t\t\t</div>\r\n\r\n    \t\t\t<!-- #BeginEditable \"headlinenews\" --><!--
+        #EndEditable -->\r\n                 \r\n                <div id=\"pageheading\">\r\n
+        \                   <h1><strong>Planning</strong>&nbsp;&ndash;&nbsp;<!-- #BeginEditable
+        \"pageheading\" -->Application Summary<!-- #EndEditable --></h1>\r\n                    <!--
+        #BeginEditable \"helplink\" -->\r\n<p class=\"pagehelp\">\r\n\t<a title=\"Help
+        with this page (opens in a new window)\" rel=\"external\" target=\"_blank\"
+        href=\"/online-applications/help/pagehelp/applications.htm\">\r\n\t\tHelp
+        with this page\r\n\t<span> (opens in a new window)</span>\r\n\t</a>\r\n</p>\r\n<!--
+        #EndEditable -->\r\n                </div>\r\n                \r\n                <!--
+        START WAM CONTENT -->\r\n                <div class=\"content\">\r\n                    <!--
+        #BeginEditable \"errormsg\" -->\n        \n        \n\n        \n        \n
+        \   <!-- #EndEditable -->\r\n                    <!-- #BeginEditable \"pagehead\"
+        -->\r\n\r\n    <div class=\"addressCrumb\">\r\n        <span class=\"caseNumber\">\r\n
+        \           \r\n\r\n            \r\n                19/00284/DCH\r\n            \r\n
+        \       </span>\r\n\r\n        <span class=\"divider1\">|</span>\r\n\r\n        \r\n
+        \           <span class=\"description\">\r\n                1ST FLOOR REAR
+        AND GROUND FLOOR SIDE EXTENSION\r\n            </span>\r\n            \r\n
+        \               <span class=\"divider2\">|</span>\r\n            \r\n        \r\n\r\n
+        \       \r\n\r\n        \r\n\r\n        \r\n        \r\n        \r\n        \r\n
+        \       \r\n            \r\n            <span class=\"address\">\r\n                3
+        RHYD Y PENAU ROAD, CYNCOED, CARDIFF, CF23 6PX\r\n            </span>\r\n        \r\n
+        \       \r\n    </div>\r\n\r\n\r\n    <div id=\"applicationTools\">\r\n        <ul>\r\n
+        \           \r\n            \r\n                \r\n                    \r\n
+        \                       \r\n                            \r\n                            \r\n
+        \                               \r\n                                    <li>\r\n
+        \                                       <a href=\"/online-applications/searchResultsBack.do?action=back\"
+        id=\"searchresultsback\">Back to search results</a>\r\n                                    </li>\r\n
+        \                               \r\n                            \r\n                        \r\n
+        \                   \r\n                    \r\n                    \r\n                \r\n
+        \           \r\n\r\n            \r\n\r\n            \r\n            \r\n\r\n
+        \           \r\n\r\n            \r\n            \r\n                \r\n                    <li>\r\n
+        \                       <form name=\"trackForm\" method=\"post\" action=\"/online-applications/registered/trackedApplicationSubmit.do?action=track\"><input
+        type=\"hidden\" name=\"org.apache.struts.taglib.html.TOKEN\" value=\"5f5511c73c77f7d6364641ff41d4b528\"
+        />\r\n                            <input type=\"hidden\" name=\"caseNo\" value=\"19/00284/DCH\"
+        />\r\n                            <input type=\"hidden\" name=\"caseType\"
+        value=\"Application\" />\r\n                            <input type=\"hidden\"
+        name=\"address\" value=\"3 RHYD Y PENAU ROAD, CYNCOED, CARDIFF, CF23 6PX\"
+        />\r\n                            <input type=\"hidden\" name=\"description\"
+        value=\"1ST FLOOR REAR AND GROUND FLOOR SIDE EXTENSION\" />\r\n                            <input
+        type=\"hidden\" name=\"status\" value=\"Decided\" />\r\n                            <input
+        type=\"hidden\" name=\"trackingStatus\" value=\"Decided\" />\r\n                            <input
+        type=\"hidden\" name=\"caseTechnicalKey\" value=\"_CARDIFF_DCAPR_126537\"
+        />\r\n                            <input class=\"casefiletrack\"\r\n                                   src=\"/online-applications-skin/images/button_track.gif\"\r\n
+        \                                  type=\"image\"\r\n                                   name=\"submit\"\r\n
+        \                                  altKey=\"casedetails.track\"\r\n                                   title=\"Get
+        informed when this item is updated\"/>\r\n                        </form>\r\n
+        \                   </li>\r\n                \r\n\r\n                \r\n
+        \           \r\n\r\n\r\n            \r\n                \r\n             \r\n
+        \           \r\n\r\n            \r\n            \r\n                \r\n            \r\n
+        \           \r\n            \r\n            <li>\r\n                <a href=\"/online-applications/applicationDetails.do?activeTab=printPreview&amp;keyVal=_CARDIFF_DCAPR_126537\"
+        id=\"print\" rel=\"external\">\r\n                    <img src=\"/online-applications-skin/images/button_print.gif\"
+        alt=\"Print summary icon\" width=\"53\" height=\"22\" border=\"0\"/>\r\n                </a>\r\n
+        \           </li>\r\n            \r\n\r\n            \r\n        </ul>\r\n\r\n
+        \   </div>\r\n\r\n\r\n     \r\n\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabs\" -->\r\n    \r\n    <ul class=\"tabs\">\r\n\r\n        \r\n\r\n
+        \           \r\n                \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/applicationDetails.do?activeTab=summary&amp;keyVal=_CARDIFF_DCAPR_126537\"
+        id=\"tab_summary\" class=\"active\">\r\n                        <span>\r\n
+        \                           Details\r\n                            \r\n                        </span>\r\n
+        \                   </a>\r\n\r\n                    \r\n                    \r\n
+        \                   \r\n                        \r\n                        \r\n\r\n
+        \                           <ul class=\"subtabs\">\r\n                                \r\n
+        \                                   \r\n                                        <li>\r\n
+        \                                           \r\n                                            <a
+        href=\"/online-applications/applicationDetails.do?activeTab=summary&amp;keyVal=_CARDIFF_DCAPR_126537\"
+        id=\"subtab_summary\" class=\"active\">\r\n                                                <span>\r\n
+        \                                                   Summary\r\n                                                    \r\n
+        \                                               </span>\r\n                                            </a>\r\n
+        \                                       </li>\r\n                                    \r\n
+        \                               \r\n                                    \r\n
+        \                                       <li>\r\n                                            \r\n
+        \                                           <a href=\"/online-applications/applicationDetails.do?activeTab=details&amp;keyVal=_CARDIFF_DCAPR_126537\"
+        id=\"subtab_details\">\r\n                                                <span>\r\n
+        \                                                   Further Information\r\n
+        \                                                   \r\n                                                </span>\r\n
+        \                                           </a>\r\n                                        </li>\r\n
+        \                                   \r\n                                \r\n
+        \                                   \r\n                                        <li>\r\n
+        \                                           \r\n                                            <a
+        href=\"/online-applications/applicationDetails.do?activeTab=contacts&amp;keyVal=_CARDIFF_DCAPR_126537\"
+        id=\"subtab_contacts\">\r\n                                                <span>\r\n
+        \                                                   Contacts\r\n                                                    \r\n
+        \                                               </span>\r\n                                            </a>\r\n
+        \                                       </li>\r\n                                    \r\n
+        \                               \r\n                                    \r\n
+        \                                       <li>\r\n                                            \r\n
+        \                                           <a href=\"/online-applications/applicationDetails.do?activeTab=dates&amp;keyVal=_CARDIFF_DCAPR_126537\"
+        id=\"subtab_dates\">\r\n                                                <span>\r\n
+        \                                                   Important Dates\r\n                                                    \r\n
+        \                                               </span>\r\n                                            </a>\r\n
+        \                                       </li>\r\n                                    \r\n
+        \                               \r\n                            </ul>\r\n\r\n
+        \                       \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n                \r\n
+        \               <li>\r\n\r\n                     \r\n                    <a
+        href=\"/online-applications/applicationDetails.do?activeTab=makeComment&amp;keyVal=_CARDIFF_DCAPR_126537\"
+        id=\"tab_makeComment\">\r\n                        <span>\r\n                            Comments\r\n
+        \                           \r\n                                \r\n                                (0)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n\r\n
+        \           \r\n                <li class=\"nodocuments\">\r\n                    <span>\r\n
+        \                       Constraints\r\n                        \r\n                            \r\n
+        \                           (0)\r\n                        \r\n                    </span>\r\n
+        \               </li>\r\n            \r\n\r\n        \r\n\r\n            \r\n
+        \               \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/applicationDetails.do?activeTab=documents&amp;keyVal=_CARDIFF_DCAPR_126537\"
+        id=\"tab_documents\">\r\n                        <span>\r\n                            Documents\r\n
+        \                           \r\n                                \r\n                                (10)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n                \r\n
+        \               <li>\r\n\r\n                     \r\n                    <a
+        href=\"/online-applications/applicationDetails.do?activeTab=relatedCases&amp;keyVal=_CARDIFF_DCAPR_126537\"
+        id=\"tab_relatedCases\">\r\n                        <span>\r\n                            Related
+        Cases\r\n                            \r\n                                \r\n
+        \                               (1)\r\n                            \r\n                        </span>\r\n
+        \                   </a>\r\n\r\n                    \r\n                    \r\n
+        \                   \r\n                </li>\r\n            \r\n\r\n            \r\n\r\n
+        \       \r\n\r\n            \r\n\r\n            \r\n\r\n        \r\n    </ul>\r\n<!--
+        #EndEditable -->\r\n                    <!-- #BeginEditable \"tabsubnav\"
+        --><!-- #EndEditable -->\r\n                    <!-- #BeginEditable \"pagebody\"
+        -->\n    \r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\n
+        \   \n        \n        \n    \n\n    \n    \n    \n    \n    \n\n    <div
+        class=\"tabcontainer\">\n\n        \n        \n        \n\n        \n        \n\n
+        \           \n            \n                \n            \n\n            \n
+        \               <table id=\"simpleDetailsTable\" summary=\"Case Details\">\n\n
+        \                   \n                    \n                        \n                            <tr>\n
+        \                               <th scope=\"row\" width=\"40%\">\n                                    Reference\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            19/00284/DCH\n
+        \                                       \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Alternative Reference\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            PP-07622839\n
+        \                                       \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Application Received\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            Tue
+        12 Feb 2019\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Application Validated\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            Thu
+        21 Feb 2019\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Address\n                                </th>\n
+        \                               <td>\n                                    \n
+        \                                       \n                                        \n
+        \                                           3 RHYD Y PENAU ROAD, CYNCOED,
+        CARDIFF, CF23 6PX\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Proposal\n                                </th>\n
+        \                               <td>\n                                    \n
+        \                                       \n                                        \n
+        \                                           1ST FLOOR REAR AND GROUND FLOOR
+        SIDE EXTENSION\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Status\n                                </th>\n
+        \                               <td>\n                                    \n
+        \                                       \n                                            <span
+        class=\"caseDetailsStatus\">Decided</span>\n                                        \n
+        \                                       \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Decision\n                                </th>\n
+        \                               <td>\n                                    \n
+        \                                       \n                                        \n
+        \                                           Permission be granted\n                                        \n
+        \                                   \n                                </td>\n
+        \                           </tr>\n                        \n                    \n
+        \                       \n                            <tr>\n                                <th
+        scope=\"row\" width=\"40%\">\n                                    Decision
+        Issued Date\n                                </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            Mon
+        08 Apr 2019\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Appeal Decision\n                                </th>\n
+        \                               <td>\n                                    \n
+        \                                       \n                                        \n
+        \                                           \n                                        \n
+        \                                   \n                                </td>\n
+        \                           </tr>\n                        \n                    \n\n
+        \               </table>\n\n                \n                \n\n                \n\n
+        \           \n\n            \n\n        \n\n        \n        \n            \n
+        \               <div id=\"summaryInfo\">\n                    \n                    \n
+        \                   \n                        \n                            \n
+        \                       \n                    \n\n                    \n                    \n
+        \                       <p class=\"associateddocument\">There are <a href=\"/online-applications/applicationDetails.do?activeTab=documents&amp;keyVal=_CARDIFF_DCAPR_126537\">10
+        documents</a> associated with this application.</p><p class=\"associatedcase\">There
+        are 0 cases associated with this application.</p><p class=\"associatedproperty\">There
+        is <a href=\"/online-applications/applicationDetails.do?activeTab=relatedCases&amp;keyVal=_CARDIFF_DCAPR_126537\">1
+        property</a> associated with this application.</p>\r\n\n                    \n
+        \               </div>\n            \n        \n\n    </div>\n<!-- #EndEditable
+        -->\r\n                    <!-- #BeginEditable \"pagefoot\" --><!-- #EndEditable
+        -->\r\n                </div>\r\n                <!-- END WAM CONTENT -->\r\n
+        \               \r\n                <p id=\"poweredBy\"><a href=\"http://www.idoxgroup.com/\"
+        target=\"_blank\" title=\"This link will open a new window\"><img src=\"/online-applications-skin/images/idox.gif\"
+        alt=\"an Idox solution\" /></a></p>\r\n            </div>\t\r\n\t\t\t<div
+        id=\"footer\">\r\n\t\t\t\t<div class=\"container\">\t\t\t\t\t\r\n\t\t\t\t\t<div
+        id=\"links\">\r\n\t\t\t\t\t\t<ul>\r\n\t\t\t\t\t\t\t<li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Site_Map/Pages/default.aspx\">Site
+        map</a></li><li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Cookies/Pages/Cookies.aspx\">Cookies</a></li><li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/New_Disclaimer/Pages/default.aspx\">Disclaimer</a></li>\r\n\t\t\t\t\t\t</ul>\r\n\t\t\t\t\t</div>\r\n\t\t\t\t\t<div
+        class=\"clear\"></div>\r\n\t\t\t\t</div>\r\n\t\t\t</div>\r\n\t\t\t<div id=\"footerBottom\">\r\n\t\t\t
+        \   <div class=\"container\">\r\n\t\t\t        <div id=\"footercontent\"><p>&copy;
+        <script type=\"text/javascript\">document.write(new Date().getFullYear());</script>
+        Cardiff Council</p></div>\r\n\t\t\t        <div class=\"clear\"></div>\r\n\t\t\t
+        \   </div>\r\n\t\t\t</div>\r\n        </div>    \r\n    </div>  \r\n    <!--
+        IDOX PA END -->           \r\n\t\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Mon, 15 Apr 2019 11:14:45 GMT
+- request:
+    method: get
+    uri: https://planningonline.cardiff.gov.uk/online-applications/applicationDetails.do?activeTab=relatedCases&keyVal=_CARDIFF_DCAPR_126537
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip,deflate,identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mechanize/2.7.6 Ruby/2.6.2p47 (http://github.com/sparklemotion/mechanize/)
+      Accept-Charset:
+      - ISO-8859-1,utf-8;q=0.7,*;q=0.7
+      Accept-Language:
+      - en-us,en;q=0.5
+      Cookie:
+      - JSESSIONID=ss9pKoHL32yHmhJQONSykek96zXCSSZ75skxJ5v1.vmidoxweblve; WSLang-CFC001=EN
+      Host:
+      - planningonline.cardiff.gov.uk
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '300'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - text/html; charset=UTF-8
+      Expires:
+      - Mon, 15 Apr 2019 11:15:18 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ua-Compatible:
+      - IE=edge
+      Server:
+      - Apache
+      Set-Cookie:
+      - WSLang-CFC001=EN; expires=Mon, 15-Apr-2069 11:15:17 GMT; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 15 Apr 2019 11:15:18 GMT
+      Content-Length:
+      - '19908'
+    body:
+      encoding: UTF-8
+      string: "\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n<!DOCTYPE
+        html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\r\n<html
+        lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\r\n<head>\r\n\t\r\n\t<!--
+        #BeginEditable \"doctitle\" -->\r\n    <title>\r\n    19/00284/DCH\r\n    |\r\n
+        \   \r\n        1ST FLOOR REAR AND GROUND FLOOR SIDE EXTENSION\r\n        \r\n
+        \       |\r\n        \r\n    \r\n\r\n    \r\n\r\n    \r\n\r\n    \r\n    \r\n
+        \   \r\n    \r\n    \r\n        \r\n        3 RHYD Y PENAU ROAD, CYNCOED,
+        CARDIFF, CF23 6PX\r\n    \r\n    \r\n    </title>\r\n<!-- #EndEditable -->\r\n
+        \   <!-- #BeginEditable \"metatags\" --><!-- #EndEditable -->\r\n\t\r\n    <meta
+        http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" />\r\n\t\r\n\t<!--
+        Customer metatags -->\r\n\t\r\n\t\r\n\t<!-- Favicon link -->\r\n    <link
+        rel=\"icon\" href=\"/online-applications-skin/images/cardiff/favicon.ico\"
+        type=\"image/x-icon\" />\r\n\t\r\n    <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/screen.css\"
+        type=\"text/css\" media=\"screen,projection\" />\r\n    <link rel=\"stylesheet\"
+        href=\"/online-applications-skin/styles/theme1.css\" type=\"text/css\"/>    \r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/print.css\"
+        type=\"text/css\" media=\"print\" />\r\n\t\r\n    <script type=\"text/javascript\"
+        src=\"/online-applications-skin/scripts/jquery.min.js\"></script>\r\n    <script
+        type=\"text/javascript\" src=\"/online-applications-skin/scripts/jquery.toolbar.idox.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/common.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/checkbox.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/amplify.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/createCommentCookie.js\"></script>\r\n
+        \       \r\n\t<!-- Customer Analytics Script -->\r\n\t\r\n\t\r\n    <script
+        type=\"text/javascript\">\r\n    \t$('html').addClass('js');\r\n    \t$(document).ready(function(){\r\n
+        \   \t\t$('.main#apply>span:first-child').attr('tabindex', '0')\r\n    \t});\r\n
+        \   </script>\r\n    \r\n    <!-- #BeginEditable \"mobile\" --><!-- #EndEditable
+        -->\r\n    <!-- #BeginEditable \"head\" --><!-- #EndEditable -->\r\n    <!--
+        #BeginEditable \"webapp\" -->\r\n\t<script type=\"text/javascript\">\r\n\t
+        \   jQuery(document).ready(function() {\t\t\r\n\t\t\tjQuery('#pa').before('<img
+        src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\" id=\"preload\"
+        />');\r\n\t\t\tjQuery('#preload').hide();\r\n\t\t\tjQuery('.tabs a#tab_documents').click(
+        function(event) {\r\n\t\t\t\t  window.clearTimeout(window.timeOutId);\r\n\t\t\t\t
+        \ window.timeOutId = window.setTimeout(function() {\r\n\t\t\t\t\t\tjQuery('.content').before('<div
+        id=\"overlay\"></div><div id=\"loading\"><div id=\"message\">Loading. Please
+        wait.... <img src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\"
+        height=\"19\" width=\"220\" style=\"background:#fff;\" /></div></div>');\r\n\t\t\t\t
+        \ },10); \r\n\t\t\t\t});\r\n\t\t\t\t\r\n\t\t});\r\n\t</script>\r\n            \r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/simple_social_share.min.css\"
+        type=\"text/css\"/>\r\n    <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/simple_social_share.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\">\r\n        $(document).ready(function(){\r\n
+        \           \r\n            \r\n            $(\"share-button\").simpleSocialShare({\r\n
+        \               sites: \"twitter,email\", \r\n                url: window.location.href,
+        \r\n                title: \"Online application\", \r\n                description:
+        \"Please look at this Planning Application: \", \r\n                shareType:
+        \"button\", \r\n                buttonSide: \"left\", \r\n                orientation:
+        \"horizontal\"\r\n            });\r\n        });\r\n\t</script>\r\n\t<!--
+        #EndEditable -->\r\n\r\n</head>\r\n<body>\r\n\r\n    <a href=\"#pageheading\"
+        class=\"sr-only\">Skip to main content</a>\r\n\r\n    <!-- IDOX PA START -->\r\n
+        \   <div id=\"idox\">\r\n        <div id=\"pa\">\r\n\t\t\t<div id=\"header\"><!--
+        Selector: Selector 1 -->\r\n<style>\r\n#langStyle{float:right; margin-top:
+        10px; margin-right: 30px; background:transparent; font-size:13px; cursor:pointer;
+        border:1px solid #fff !important;border-radius:2px; z-index:999; background-color:
+        #fff; padding:2px;}\r\n#langStyle:hover{text-decoration: underline;}</style>\r\n<div>\r\n\r\n<!--CYS--><a
+        id=\"langStyle\" href=\"/online-applications/applicationDetails.do?activeTab=relatedCases&keyVal=_CARDIFF_DCAPR_126537&lang=CY\">Cymraeg</a><!--CYE-->\r\n</div>\r\n\t\t\t\t<div
+        class=\"container\">\r\n\t\t\t\t\t<div id=\"logo\"><a href=\"https://www.cardiff.gov.uk/\"
+        title=\"Cardiff Council home page\"><img src=\"/online-applications-skin/images/cardiff/logo.png\"
+        alt=\"Council logo\" /><span class=\"sr-only\">Cardiff Council</span></a></div>\r\n\t\t\t\t\t<div
+        id=\"headertitle\"><span></span></div>\r\n\t\t\t\t\t<div class=\"clear\"></div>\r\n\t\t\t\t</div>\t\r\n\t\t\t</div>\r\n\t\t\t<div
+        id=\"breadcrumbs\" class=\"container\">\r\n\t\t\t\t<ul>\r\n\t\t\t\t\t\r\n\t\t\t\t</ul>\r\n\t\t\t</div>\r\n
+        \           <div class=\"container\">\r\n       \t\t\t<div id=\"toolbar\"
+        class=\"nojs\">\r\n                    <ul>\t\r\n                        <li
+        id=\"search\" class=\"main\"><span tabindex=\"0\">Search&nbsp;</span><span
+        class=\"caret\"></span>\r\n   \t\t\t\t\t\t\t<ul>\t\r\n\t\t\t\t\t\t\t\t<!--
+        #BeginLibraryItem \"/Library/searchModulesNavItems.lbi\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \       \r\n            <li id=\"planLinks\">\r\n                <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\"
+        >\r\n                    <span>Planning</span>\r\n                </a>\r\n
+        \               <ul>\r\n                    <li id=\"planBasicSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\">\r\n
+        \                           Simple Search\r\n                        </a>\r\n
+        \                   </li>\r\n\r\n                    <li id=\"planAdvancedSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=advanced&amp;searchType=Application\">\r\n
+        \                           Advanced\r\n                        </a>\r\n                    </li>\r\n
+        \                   <li id=\"planListSearch\">\r\n                        <a
+        href=\"/online-applications/search.do?action=weeklyList&amp;searchType=Application\">\r\n
+        \                           Weekly/Monthly Lists\r\n                        </a>\r\n
+        \                   </li>\r\n                    <li id=\"planPropertySearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=property&amp;type=custom\">\r\n
+        \                           Property Search\r\n                        </a>\r\n
+        \                   </li>\r\n\t\t\t\t\t\r\n                    \r\n\t\t\t\t\t\r\n
+        \               </ul>\r\n            </li>\r\n        \r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        <!-- #EndLibraryItem -->\r\n                        \t</ul>\r\n\t\t\t\t\t\t</li>\r\n
+        \                       <!-- #BeginEditable \"applicationForms\" -->\n\n\n\n\n\n
+        \  \n<!-- #EndEditable -->   \t\t\t\t\r\n                        <li id=\"myprofile\"
+        class=\"main\"><span tabindex=\"0\">My Profile&nbsp;</span><span class=\"caret\"></span>\r\n
+        \                           <ul>\r\n                              <!-- #BeginLibraryItem
+        \"/Library/consulteeInTrayNavItem.lbi\" -->\n\n\n\n\n\n\n    <!-- #EndLibraryItem
+        -->\r\n                                <li><a href=\"/online-applications/registered/displayUserDetails.do\">Profile
+        Details</a></li>\r\n                                <li><a href=\"/online-applications/registered/savedSearch.do?action=display\">Saved
+        Searches</a></li>\r\n                                <li><a href=\"/online-applications/registered/userAdmin.do?action=showNotifiedApplications\">Notified
+        Applications</a></li>\r\n                                <li><a href=\"/online-applications/registered/trackedApplication.do?action=display\">Tracked
+        Applications</a></li>\r\n                                <!-- #BeginEditable
+        \"formSubmissions\" -->\n\n\n\n\n\n\n\n\n<!-- #EndEditable -->    \t\r\n                            </ul>\r\n
+        \                       </li>\r\n                        <li id=\"loginLink\"
+        class=\"main\"><!-- #BeginEditable \"loginlogout\" -->\n\n\n\n\n\n\n\n\n\n\n\t<a
+        href=\"/online-applications/registered/userAdmin.do\">Login</a>\n<!-- #EndEditable
+        --></li>\r\n                        <!-- #BeginEditable \"register\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \  \r\n\r\n\r\n\t<li id=\"register\">\r\n        <a href=\"/online-applications/registrationWizard.do?action=start\">Register</a>\r\n\t</li>\r\n\r\n<!--
+        #EndEditable -->\r\n                        <!-- #BeginLibraryItem \"/Library/applyOnlineNavItems.lbi\"
+        -->\r\n\r\n\r\n\r\n\r\n\r\n<!-- #EndLibraryItem -->\r\n                    </ul>\r\n
+        \   \t\t\t</div>\r\n\r\n    \t\t\t<!-- #BeginEditable \"headlinenews\" --><!--
+        #EndEditable -->\r\n                 \r\n                <div id=\"pageheading\">\r\n
+        \                   <h1><strong>Planning</strong>&nbsp;&ndash;&nbsp;<!-- #BeginEditable
+        \"pageheading\" -->Application Related Items<!-- #EndEditable --></h1>\r\n
+        \                   <!-- #BeginEditable \"helplink\" -->\r\n<p class=\"pagehelp\">\r\n\t<a
+        title=\"Help with this page (opens in a new window)\" rel=\"external\" target=\"_blank\"
+        href=\"/online-applications/help/pagehelp/applications.htm\">\r\n\t\tHelp
+        with this page\r\n\t<span> (opens in a new window)</span>\r\n\t</a>\r\n</p>\r\n<!--
+        #EndEditable -->\r\n                </div>\r\n                \r\n                <!--
+        START WAM CONTENT -->\r\n                <div class=\"content\">\r\n                    <!--
+        #BeginEditable \"errormsg\" --><!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"pagehead\" -->\r\n\r\n    <div class=\"addressCrumb\">\r\n
+        \       <span class=\"caseNumber\">\r\n            \r\n\r\n            \r\n
+        \               19/00284/DCH\r\n            \r\n        </span>\r\n\r\n        <span
+        class=\"divider1\">|</span>\r\n\r\n        \r\n            <span class=\"description\">\r\n
+        \               1ST FLOOR REAR AND GROUND FLOOR SIDE EXTENSION\r\n            </span>\r\n
+        \           \r\n                <span class=\"divider2\">|</span>\r\n            \r\n
+        \       \r\n\r\n        \r\n\r\n        \r\n\r\n        \r\n        \r\n        \r\n
+        \       \r\n        \r\n            \r\n            <span class=\"address\">\r\n
+        \               3 RHYD Y PENAU ROAD, CYNCOED, CARDIFF, CF23 6PX\r\n            </span>\r\n
+        \       \r\n        \r\n    </div>\r\n\r\n\r\n    <div id=\"applicationTools\">\r\n
+        \       <ul>\r\n            \r\n            \r\n                \r\n                    \r\n
+        \                       \r\n                            \r\n                            \r\n
+        \                               \r\n                                    <li>\r\n
+        \                                       <a href=\"/online-applications/searchResultsBack.do?action=back\"
+        id=\"searchresultsback\">Back to search results</a>\r\n                                    </li>\r\n
+        \                               \r\n                            \r\n                        \r\n
+        \                   \r\n                    \r\n                    \r\n                \r\n
+        \           \r\n\r\n            \r\n\r\n            \r\n            \r\n\r\n
+        \           \r\n\r\n            \r\n            \r\n                \r\n                    <li>\r\n
+        \                       <form name=\"trackForm\" method=\"post\" action=\"/online-applications/registered/trackedApplicationSubmit.do?action=track\"><input
+        type=\"hidden\" name=\"org.apache.struts.taglib.html.TOKEN\" value=\"5f5511c73c77f7d6364641ff41d4b528\"
+        />\r\n                            <input type=\"hidden\" name=\"caseNo\" value=\"19/00284/DCH\"
+        />\r\n                            <input type=\"hidden\" name=\"caseType\"
+        value=\"Application\" />\r\n                            <input type=\"hidden\"
+        name=\"address\" value=\"3 RHYD Y PENAU ROAD, CYNCOED, CARDIFF, CF23 6PX\"
+        />\r\n                            <input type=\"hidden\" name=\"description\"
+        value=\"1ST FLOOR REAR AND GROUND FLOOR SIDE EXTENSION\" />\r\n                            <input
+        type=\"hidden\" name=\"status\" value=\"Decided\" />\r\n                            <input
+        type=\"hidden\" name=\"trackingStatus\" value=\"Decided\" />\r\n                            <input
+        type=\"hidden\" name=\"caseTechnicalKey\" value=\"_CARDIFF_DCAPR_126537\"
+        />\r\n                            <input class=\"casefiletrack\"\r\n                                   src=\"/online-applications-skin/images/button_track.gif\"\r\n
+        \                                  type=\"image\"\r\n                                   name=\"submit\"\r\n
+        \                                  altKey=\"casedetails.track\"\r\n                                   title=\"Get
+        informed when this item is updated\"/>\r\n                        </form>\r\n
+        \                   </li>\r\n                \r\n\r\n                \r\n
+        \           \r\n\r\n\r\n            \r\n                \r\n             \r\n
+        \           \r\n\r\n            \r\n            \r\n                \r\n            \r\n
+        \           \r\n            \r\n            <li>\r\n                <a href=\"/online-applications/applicationDetails.do?activeTab=printPreview&amp;keyVal=_CARDIFF_DCAPR_126537\"
+        id=\"print\" rel=\"external\">\r\n                    <img src=\"/online-applications-skin/images/button_print.gif\"
+        alt=\"Print summary icon\" width=\"53\" height=\"22\" border=\"0\"/>\r\n                </a>\r\n
+        \           </li>\r\n            \r\n\r\n            \r\n        </ul>\r\n\r\n
+        \   </div>\r\n\r\n\r\n     \r\n\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabs\" -->\r\n    \r\n    <ul class=\"tabs\">\r\n\r\n        \r\n\r\n
+        \           \r\n                \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/applicationDetails.do?activeTab=summary&amp;keyVal=_CARDIFF_DCAPR_126537\"
+        id=\"tab_summary\">\r\n                        <span>\r\n                            Details\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n                \r\n
+        \               <li>\r\n\r\n                     \r\n                    <a
+        href=\"/online-applications/applicationDetails.do?activeTab=makeComment&amp;keyVal=_CARDIFF_DCAPR_126537\"
+        id=\"tab_makeComment\">\r\n                        <span>\r\n                            Comments\r\n
+        \                           \r\n                                \r\n                                (0)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n\r\n
+        \           \r\n                <li class=\"nodocuments\">\r\n                    <span>\r\n
+        \                       Constraints\r\n                        \r\n                            \r\n
+        \                           (0)\r\n                        \r\n                    </span>\r\n
+        \               </li>\r\n            \r\n\r\n        \r\n\r\n            \r\n
+        \               \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/applicationDetails.do?activeTab=documents&amp;keyVal=_CARDIFF_DCAPR_126537\"
+        id=\"tab_documents\">\r\n                        <span>\r\n                            Documents\r\n
+        \                           \r\n                                \r\n                                (10)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n                \r\n
+        \               <li>\r\n\r\n                     \r\n                    <a
+        href=\"/online-applications/applicationDetails.do?activeTab=relatedCases&amp;keyVal=_CARDIFF_DCAPR_126537\"
+        id=\"tab_relatedCases\" class=\"active\">\r\n                        <span>\r\n
+        \                           Related Cases\r\n                            \r\n
+        \                               \r\n                                (1)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                        \r\n
+        \                       \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n\r\n
+        \           \r\n\r\n        \r\n    </ul>\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabsubnav\" --><!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"pagebody\" -->\r\n\r\n    \r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \   <div class=\"tabcontainer toplevel\">\r\n    <div id=\"relatedItems\">\r\n\r\n
+        \       \r\n            \r\n            \r\n\r\n            <!-- Display header
+        -->\r\n            <div id=\"Application\">\r\n                <h3>\r\n                    \r\n
+        \                   \r\n                        Planning Applications\r\n
+        \                   \r\n                    <span>(0)</span>\r\n                </h3>\n\r\n\r\n
+        \               <!-- Display each item -->\r\n                \r\n            </div>\r\n\r\n
+        \       \r\n            \r\n            \r\n\r\n            <!-- Display header
+        -->\r\n            <div id=\"Appeal\">\r\n                <h3>\r\n                    \r\n
+        \                   \r\n                        Planning Appeals\r\n                    \r\n
+        \                   <span>(0)</span>\r\n                </h3>\n\r\n\r\n                <!--
+        Display each item -->\r\n                \r\n            </div>\r\n\r\n        \r\n
+        \           \r\n            \r\n\r\n            <!-- Display header -->\r\n
+        \           <div id=\"Enforcement\">\r\n                <h3>\r\n                    \r\n
+        \                   \r\n                        Planning Enforcements\r\n
+        \                   \r\n                    <span>(0)</span>\r\n                </h3>\n\r\n\r\n
+        \               <!-- Display each item -->\r\n                \r\n            </div>\r\n\r\n
+        \       \r\n            \r\n            \r\n\r\n            <!-- Display header
+        -->\r\n            <div id=\"Property\">\r\n                <h3>\r\n                    \r\n
+        \                   \r\n                        Properties\r\n                    \r\n
+        \                   <span>(1)</span>\r\n                </h3>\n\r\n\r\n                <!--
+        Display each item -->\r\n                \r\n                    <ul>\r\n
+        \                       \r\n                            <li>\r\n                                \r\n
+        \                               \r\n                                \r\n\r\n
+        \                               <a href=\"/online-applications/propertyDetails.do?previousCaseType=Application&amp;keyVal=_CARDIFF_PROPLPI_113940_1&amp;previousCaseNumber=19%2F00284%2FDCH&amp;activeTab=summary&amp;previousKeyVal=_CARDIFF_DCAPR_126537\">\r\n
+        \                                   3 RHYD Y PENAU ROAD, CYNCOED, CARDIFF,
+        CF23 6PX\r\n                                </a>\r\n\r\n                                <p
+        class=\"metaInfo\">\r\n\r\n                                \r\n\r\n                                \r\n\r\n
+        \                               \r\n                                \r\n                                \r\n
+        \                              </p>\r\n                            </li>\r\n
+        \                       \r\n                    </ul>\r\n                \r\n
+        \           </div>\r\n\r\n        \r\n\r\n    </div>\r\n    </div>\r\n\r\n<!--
+        #EndEditable -->\r\n                    <!-- #BeginEditable \"pagefoot\" --><!--
+        #EndEditable -->\r\n                </div>\r\n                <!-- END WAM
+        CONTENT -->\r\n                \r\n                <p id=\"poweredBy\"><a
+        href=\"http://www.idoxgroup.com/\" target=\"_blank\" title=\"This link will
+        open a new window\"><img src=\"/online-applications-skin/images/idox.gif\"
+        alt=\"an Idox solution\" /></a></p>\r\n            </div>\t\r\n\t\t\t<div
+        id=\"footer\">\r\n\t\t\t\t<div class=\"container\">\t\t\t\t\t\r\n\t\t\t\t\t<div
+        id=\"links\">\r\n\t\t\t\t\t\t<ul>\r\n\t\t\t\t\t\t\t<li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Site_Map/Pages/default.aspx\">Site
+        map</a></li><li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Cookies/Pages/Cookies.aspx\">Cookies</a></li><li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/New_Disclaimer/Pages/default.aspx\">Disclaimer</a></li>\r\n\t\t\t\t\t\t</ul>\r\n\t\t\t\t\t</div>\r\n\t\t\t\t\t<div
+        class=\"clear\"></div>\r\n\t\t\t\t</div>\r\n\t\t\t</div>\r\n\t\t\t<div id=\"footerBottom\">\r\n\t\t\t
+        \   <div class=\"container\">\r\n\t\t\t        <div id=\"footercontent\"><p>&copy;
+        <script type=\"text/javascript\">document.write(new Date().getFullYear());</script>
+        Cardiff Council</p></div>\r\n\t\t\t        <div class=\"clear\"></div>\r\n\t\t\t
+        \   </div>\r\n\t\t\t</div>\r\n        </div>    \r\n    </div>  \r\n    <!--
+        IDOX PA END -->           \r\n\t\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Mon, 15 Apr 2019 11:14:47 GMT
+- request:
+    method: get
+    uri: https://planningonline.cardiff.gov.uk/online-applications/propertyDetails.do?activeTab=summary&keyVal=_CARDIFF_PROPLPI_113940_1&previousCaseNumber=19/00284/DCH&previousCaseType=Application&previousKeyVal=_CARDIFF_DCAPR_126537
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip,deflate,identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mechanize/2.7.6 Ruby/2.6.2p47 (http://github.com/sparklemotion/mechanize/)
+      Accept-Charset:
+      - ISO-8859-1,utf-8;q=0.7,*;q=0.7
+      Accept-Language:
+      - en-us,en;q=0.5
+      Cookie:
+      - JSESSIONID=ss9pKoHL32yHmhJQONSykek96zXCSSZ75skxJ5v1.vmidoxweblve; WSLang-CFC001=EN
+      Host:
+      - planningonline.cardiff.gov.uk
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '300'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - text/html; charset=UTF-8
+      Expires:
+      - Mon, 15 Apr 2019 11:15:20 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ua-Compatible:
+      - IE=edge
+      Server:
+      - Apache
+      Set-Cookie:
+      - WSLang-CFC001=EN; expires=Mon, 15-Apr-2069 11:15:18 GMT; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 15 Apr 2019 11:15:20 GMT
+      Content-Length:
+      - '13518'
+    body:
+      encoding: UTF-8
+      string: "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n    \n\n    \n\n<!DOCTYPE html PUBLIC
+        \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\r\n<html
+        lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\r\n<head>\r\n\r\n\t<!--
+        #BeginEditable \"doctitle\" -->\r\n    <title>\r\n    _CARDIFF_PROPLPI_113940_1\r\n
+        \   |\r\n    \r\n\r\n    \r\n\r\n    \r\n\r\n    \r\n    \r\n    \r\n    \r\n
+        \   \r\n        \r\n        3 RHYD Y PENAU ROAD, CYNCOED, CARDIFF, CF23 6PX\r\n
+        \   \r\n    \r\n    </title>\r\n<!-- #EndEditable -->\r\n    <!-- #BeginEditable
+        \"metatags\" --><!-- #EndEditable -->\r\n\t\r\n    <meta http-equiv=\"Content-Type\"
+        content=\"text/html; charset=UTF-8\" />\r\n\t\r\n\t<!-- Customer metatags
+        -->\r\n\t\r\n\t\r\n\t<!-- Favicon link -->\r\n    <link rel=\"icon\" href=\"/online-applications-skin/images/cardiff/favicon.ico\"
+        type=\"image/x-icon\" />\r\n\t\r\n    <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/screen.css\"
+        type=\"text/css\" media=\"screen,projection\" />\r\n    <link rel=\"stylesheet\"
+        href=\"/online-applications-skin/styles/theme1.css\" type=\"text/css\"/>\t\r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/print.css\"
+        type=\"text/css\" media=\"print\" />   \r\n\r\n    <script type=\"text/javascript\"
+        src=\"/online-applications-skin/scripts/jquery.min.js\"></script>\r\n    <script
+        type=\"text/javascript\" src=\"/online-applications-skin/scripts/jquery.toolbar.idox.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/common.js\"></script>\r\n
+        \       \r\n\t<!-- Customer Analytics Script -->\r\n\t\r\n\t\r\n    <script
+        type=\"text/javascript\">\r\n    \t$('html').addClass('js');\r\n    \t$(document).ready(function(){\r\n
+        \   \t\t$('.main#apply>span:first-child').attr('tabindex', '0')\r\n    \t});\r\n
+        \   </script>\r\n    \r\n    <!-- #BeginEditable \"mobile\" --><!-- #EndEditable
+        -->\r\n    <!-- #BeginEditable \"head\" --><!-- #EndEditable -->\r\n    <!--
+        #BeginEditable \"webapp\" --><!-- #EndEditable -->\r\n\r\n</head>\r\n<body>\r\n\r\n
+        \   <a href=\"#pageheading\" class=\"sr-only\">Skip to main content</a>\r\n\r\n
+        \   <!-- IDOX PA START -->\r\n    <div id=\"idox\">\r\n        <div id=\"pa\">
+        \r\n\t\t\t<div id=\"header\"><!-- Selector: Selector 1 -->\r\n<style>\r\n#langStyle{float:right;
+        margin-top: 10px; margin-right: 30px; background:transparent; font-size:13px;
+        cursor:pointer; border:1px solid #fff !important;border-radius:2px; z-index:999;
+        background-color: #fff; padding:2px;}\r\n#langStyle:hover{text-decoration:
+        underline;}</style>\r\n<div>\r\n\r\n<!--CYS--><a id=\"langStyle\" href=\"/online-applications/propertyDetails.do?previousCaseType=Application&keyVal=_CARDIFF_PROPLPI_113940_1&previousCaseNumber=19%2f00284%2fDCH&activeTab=summary&previousKeyVal=_CARDIFF_DCAPR_126537&lang=CY\">Cymraeg</a><!--CYE-->\r\n</div>\r\n\t\t\t\t<div
+        class=\"container\">\r\n\t\t\t\t\t<div id=\"logo\"><a href=\"https://www.cardiff.gov.uk/\"
+        title=\"Cardiff Council home page\"><img src=\"/online-applications-skin/images/cardiff/logo.png\"
+        alt=\"Council logo\" /><span class=\"sr-only\">Cardiff Council</span></a></div>\r\n\t\t\t\t\t<div
+        id=\"headertitle\"><span></span></div>\r\n\t\t\t\t\t<div class=\"clear\"></div>\r\n\t\t\t\t</div>\t\r\n\t\t\t</div>\r\n\t\t\t<div
+        id=\"breadcrumbs\" class=\"container\">\r\n\t\t\t\t<ul>\r\n\t\t\t\t\t\r\n\t\t\t\t</ul>\r\n\t\t\t</div>\r\n
+        \           <div class=\"container\">\r\n                <div id=\"toolbar\"
+        class=\"nojs\">\r\n                    <ul>\t\r\n                        <li
+        id=\"search\" class=\"main\"><span tabindex=\"0\">Search&nbsp;</span><span
+        class=\"caret\"></span>\r\n   \t\t\t\t\t\t\t<ul>\t\r\n\t\t\t\t\t\t\t\t<!--
+        #BeginLibraryItem \"/Library/searchModulesNavItems.lbi\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \       \r\n            <li id=\"planLinks\">\r\n                <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\"
+        >\r\n                    <span>Planning</span>\r\n                </a>\r\n
+        \               <ul>\r\n                    <li id=\"planBasicSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\">\r\n
+        \                           Simple Search\r\n                        </a>\r\n
+        \                   </li>\r\n\r\n                    <li id=\"planAdvancedSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=advanced&amp;searchType=Application\">\r\n
+        \                           Advanced\r\n                        </a>\r\n                    </li>\r\n
+        \                   <li id=\"planListSearch\">\r\n                        <a
+        href=\"/online-applications/search.do?action=weeklyList&amp;searchType=Application\">\r\n
+        \                           Weekly/Monthly Lists\r\n                        </a>\r\n
+        \                   </li>\r\n                    <li id=\"planPropertySearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=property&amp;type=custom\">\r\n
+        \                           Property Search\r\n                        </a>\r\n
+        \                   </li>\r\n\t\t\t\t\t\r\n                    \r\n\t\t\t\t\t\r\n
+        \               </ul>\r\n            </li>\r\n        \r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        <!-- #EndLibraryItem -->\r\n                        \t</ul>\r\n\t\t\t\t\t\t</li>\r\n
+        \                       <!-- #BeginEditable \"applicationForms\" -->\n\n\n\n\n\n
+        \  \n<!-- #EndEditable -->   \t\t\t\t\r\n                        <li id=\"myprofile\"
+        class=\"main\"><span tabindex=\"0\">My Profile&nbsp;</span><span class=\"caret\"></span>\r\n
+        \                           <ul>\r\n                              <!-- #BeginLibraryItem
+        \"/Library/consulteeInTrayNavItem.lbi\" -->\n\n\n\n\n\n\n    <!-- #EndLibraryItem
+        -->\r\n                                <li><a href=\"/online-applications/registered/displayUserDetails.do\">Profile
+        Details</a></li>\r\n                                <li><a href=\"/online-applications/registered/savedSearch.do?action=display\">Saved
+        Searches</a></li>\r\n                                <li><a href=\"/online-applications/registered/userAdmin.do?action=showNotifiedApplications\">Notified
+        Applications</a></li>\r\n                                <li><a href=\"/online-applications/registered/trackedApplication.do?action=display\">Tracked
+        Applications</a></li>\r\n                                <!-- #BeginEditable
+        \"formSubmissions\" -->\n\n\n\n\n\n\n\n\n<!-- #EndEditable -->    \t\r\n                            </ul>\r\n
+        \                       </li>\r\n                        <li id=\"loginLink\"
+        class=\"main\"><!-- #BeginEditable \"loginlogout\" -->\n\n\n\n\n\n\n\n\n\n\n\t<a
+        href=\"/online-applications/registered/userAdmin.do\">Login</a>\n<!-- #EndEditable
+        --></li>\r\n                        <!-- #BeginEditable \"register\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \  \r\n\r\n\r\n\t<li id=\"register\">\r\n        <a href=\"/online-applications/registrationWizard.do?action=start\">Register</a>\r\n\t</li>\r\n\r\n<!--
+        #EndEditable -->\r\n                        <!-- #BeginLibraryItem \"/Library/applyOnlineNavItems.lbi\"
+        -->\r\n\r\n\r\n\r\n\r\n\r\n<!-- #EndLibraryItem -->\r\n                    </ul>\r\n
+        \   \t\t\t</div>\r\n                \r\n                <div id=\"pageheading\">\r\n
+        \                   <h1><!-- #BeginEditable \"pageheading\" -->Property Address<!--
+        #EndEditable --></h1>\r\n                    <!-- #BeginEditable \"helplink\"
+        -->\r\n<p class=\"pagehelp\">\r\n\t<a title=\"Help with this page (opens in
+        a new window)\" rel=\"external\" target=\"_blank\" href=\"/online-applications/help/pagehelp/properties.htm\">\r\n\t\tHelp
+        with this page\r\n\t<span> (opens in a new window)</span>\r\n\t</a>\r\n</p>\r\n<!--
+        #EndEditable -->\r\n                </div>\r\n        \r\n                <!--
+        START WAM CONTENT -->\r\n                <div class=\"content\">\r\n                    <!--
+        #BeginEditable \"errormsg\" -->\n        \n        \n\n        \n        \n
+        \   <!-- #EndEditable -->\r\n                    <!-- #BeginEditable \"pagehead\"
+        -->\r\n\r\n    <div class=\"addressCrumb\">\r\n        <span class=\"caseNumber\">\r\n
+        \           \r\n                100100044782 \r\n            \r\n\r\n            \r\n
+        \       </span>\r\n\r\n        <span class=\"divider1\">|</span>\r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        \r\n\r\n        \r\n        \r\n        \r\n        \r\n
+        \       \r\n            \r\n            <span class=\"address\">\r\n                3
+        RHYD Y PENAU ROAD, CYNCOED, CARDIFF, CF23 6PX\r\n            </span>\r\n        \r\n
+        \       \r\n    </div>\r\n\r\n\r\n    <div id=\"applicationTools\">\r\n        <ul>\r\n
+        \           \r\n            \r\n\r\n            \r\n\r\n            \r\n            \r\n
+        \               <li>\r\n                    <a href=\"/online-applications/applicationDetails.do?keyVal=_CARDIFF_DCAPR_126537&amp;activeTab=summary\"
+        id=\"searchresultsback\">\r\n                        Planning Application\r\n
+        \                       \r\n                        \r\n                            19/00284/DCH\r\n
+        \                       \r\n                    </a>\r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n            \r\n            \r\n\r\n\r\n
+        \           \r\n                \r\n             \r\n            \r\n\r\n
+        \           \r\n            \r\n                \r\n            \r\n            \r\n
+        \           \r\n            <li>\r\n                <a href=\"/online-applications/propertyDetails.do?activeTab=printPreview&amp;keyVal=_CARDIFF_PROPLPI_113940_1\"
+        id=\"print\" rel=\"external\">\r\n                    <img src=\"/online-applications-skin/images/button_print.gif\"
+        alt=\"Print summary icon\" width=\"53\" height=\"22\" border=\"0\"/>\r\n                </a>\r\n
+        \           </li>\r\n            \r\n\r\n            \r\n        </ul>\r\n\r\n
+        \   </div>\r\n\r\n\r\n     \r\n\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabs\" -->\r\n    \r\n    <ul class=\"tabs\">\r\n\r\n        \r\n\r\n
+        \           \r\n                \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/propertyDetails.do?activeTab=summary&amp;keyVal=_CARDIFF_PROPLPI_113940_1\"
+        id=\"tab_summary\" class=\"active\">\r\n                        <span>\r\n
+        \                           Address\r\n                            \r\n                        </span>\r\n
+        \                   </a>\r\n\r\n                    \r\n                    \r\n
+        \                   \r\n                        \r\n                        \r\n
+        \                   \r\n                </li>\r\n            \r\n\r\n            \r\n\r\n
+        \       \r\n\r\n            \r\n                \r\n                <li>\r\n\r\n
+        \                    \r\n                    <a href=\"/online-applications/propertyDetails.do?activeTab=relatedCases&amp;keyVal=_CARDIFF_PROPLPI_113940_1\"
+        id=\"tab_relatedCases\">\r\n                        <span>\r\n                            Property
+        History\r\n                            \r\n                                \r\n
+        \                               (1)\r\n                            \r\n                        </span>\r\n
+        \                   </a>\r\n\r\n                    \r\n                    \r\n
+        \                   \r\n                </li>\r\n            \r\n\r\n            \r\n\r\n
+        \       \r\n\r\n            \r\n                \r\n                <li>\r\n\r\n
+        \                    \r\n                    <a href=\"/online-applications/propertyDetails.do?activeTab=constraints&amp;keyVal=_CARDIFF_PROPLPI_113940_1\"
+        id=\"tab_constraints\">\r\n                        <span>\r\n                            Constraints\r\n
+        \                           \r\n                                \r\n                                (1)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n\r\n
+        \           \r\n\r\n        \r\n    </ul>\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabsubnav\" --><!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"pagebody\" -->\n    \r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\n
+        \   \n        \n        \n    \n\n    \n    \n    \n    \n    \n        \n
+        \       \n    \n\n    <div class=\"tabcontainer toplevel\">\n\n        \n
+        \       \n        \n            \n            <table id=\"propertyAddress\"
+        summary=\"Property address\">\r\n<tr class=\"row0\">\r\n<th scope=\"row\">UPRN:</th>\r\n<td>100100044782</td>\r\n</tr>\r\n<tr
+        class=\"row1\">\r\n<th scope=\"row\">Full Address:</th>\r\n<td>3 RHYD Y PENAU
+        ROAD, CYNCOED, CARDIFF, CF23 6PX</td>\r\n</tr>\r\n<tr class=\"row1\">\r\n<th
+        scope=\"row\">Property Number:</th>\r\n<td>3</td>\r\n</tr>\r\n<tr class=\"row0\">\r\n<th
+        scope=\"row\">Street:</th>\r\n<td>RHYD Y PENAU ROAD</td>\r\n</tr>\r\n<tr class=\"row1\">\r\n<th
+        scope=\"row\">Town:</th>\r\n<td>CARDIFF</td>\r\n</tr>\r\n<tr class=\"row0\">\r\n<th
+        scope=\"row\">Postcode:</th>\r\n<td>CF23 6PX</td>\r\n</tr>\r\n<tr class=\"row1\">\r\n<th
+        scope=\"row\">Ward:</th>\r\n<td>CYNCOED</td>\r\n</tr>\r\n<tr class=\"row0\">\r\n<th
+        scope=\"row\">Parish:</th>\r\n<td/>\r\n</tr>\r\n</table>\r\n\n        \n\n
+        \       \n        \n\n        \n        \n            \n        \n\n    </div>\n<!--
+        #EndEditable -->\r\n                    <!-- #BeginEditable \"pagefoot\" --><!--
+        #EndEditable -->\r\n                </div>\r\n                <!-- END WAM
+        CONTENT -->\r\n                \r\n                <p id=\"poweredBy\"><a
+        href=\"http://www.idoxgroup.com/\" target=\"_blank\" title=\"This link will
+        open a new window\"><img src=\"/online-applications-skin/images/idox.gif\"
+        alt=\"an Idox solution\" /></a></p>\r\n            </div>\r\n\t\t\t<div id=\"footer\">\r\n\t\t\t\t<div
+        class=\"container\">\t\t\t\t\t\r\n\t\t\t\t\t<div id=\"links\">\r\n\t\t\t\t\t\t<ul>\r\n\t\t\t\t\t\t\t<li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/Site_Map/Pages/default.aspx\">Site
+        map</a></li><li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Cookies/Pages/Cookies.aspx\">Cookies</a></li><li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/New_Disclaimer/Pages/default.aspx\">Disclaimer</a></li>\r\n\t\t\t\t\t\t</ul>\r\n\t\t\t\t\t</div>\r\n\t\t\t\t\t<div
+        class=\"clear\"></div>\r\n\t\t\t\t</div>\r\n\t\t\t</div>\r\n\t\t\t<div id=\"footerBottom\">\r\n\t\t\t
+        \   <div class=\"container\">\r\n\t\t\t        <div id=\"footercontent\"><p>&copy;
+        <script type=\"text/javascript\">document.write(new Date().getFullYear());</script>
+        Cardiff Council</p></div>\r\n\t\t\t        <div class=\"clear\"></div>\r\n\t\t\t
+        \   </div>\r\n\t\t\t</div>\r\n        </div>\r\n    </div>\r\n    <!-- IDOX
+        PA END -->\r\n\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Mon, 15 Apr 2019 11:14:49 GMT
+- request:
+    method: get
+    uri: https://planningonline.cardiff.gov.uk/online-applications/applicationDetails.do?activeTab=summary&keyVal=_CARDIFF_DCAPR_126508
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip,deflate,identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mechanize/2.7.6 Ruby/2.6.2p47 (http://github.com/sparklemotion/mechanize/)
+      Accept-Charset:
+      - ISO-8859-1,utf-8;q=0.7,*;q=0.7
+      Accept-Language:
+      - en-us,en;q=0.5
+      Cookie:
+      - JSESSIONID=ss9pKoHL32yHmhJQONSykek96zXCSSZ75skxJ5v1.vmidoxweblve; WSLang-CFC001=EN
+      Host:
+      - planningonline.cardiff.gov.uk
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '300'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - text/html; charset=UTF-8
+      Expires:
+      - Mon, 15 Apr 2019 11:15:35 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ua-Compatible:
+      - IE=edge
+      Server:
+      - Apache
+      Set-Cookie:
+      - WSLang-CFC001=EN; expires=Mon, 15-Apr-2069 11:15:30 GMT; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 15 Apr 2019 11:15:35 GMT
+      Content-Length:
+      - '28544'
+    body:
+      encoding: UTF-8
+      string: "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n    \n\n    \n\n<!DOCTYPE html PUBLIC
+        \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\r\n<html
+        lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\r\n<head>\r\n\t\r\n\t<!--
+        #BeginEditable \"doctitle\" -->\r\n    <title>\r\n    19/00263/DCH\r\n    |\r\n
+        \   \r\n        VARIATION OF CONDITION 2 (APPROVED PLANS) OF 17/03122/DCH\r\n
+        \       \r\n        |\r\n        \r\n    \r\n\r\n    \r\n\r\n    \r\n\r\n
+        \   \r\n    \r\n    \r\n    \r\n    \r\n        \r\n        MILL FARM HOUSE,
+        MILL FARM, ST MELLONS ROAD, LISVANE, CARDIFF, CF14 0SH\r\n    \r\n    \r\n
+        \   </title>\r\n<!-- #EndEditable -->\r\n    <!-- #BeginEditable \"metatags\"
+        --><!-- #EndEditable -->\r\n\t\r\n    <meta http-equiv=\"Content-Type\" content=\"text/html;
+        charset=UTF-8\" />\r\n\t\r\n\t<!-- Customer metatags -->\r\n\t\r\n\t\r\n\t<!--
+        Favicon link -->\r\n    <link rel=\"icon\" href=\"/online-applications-skin/images/cardiff/favicon.ico\"
+        type=\"image/x-icon\" />\r\n\t\r\n    <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/screen.css\"
+        type=\"text/css\" media=\"screen,projection\" />\r\n    <link rel=\"stylesheet\"
+        href=\"/online-applications-skin/styles/theme1.css\" type=\"text/css\"/>    \r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/print.css\"
+        type=\"text/css\" media=\"print\" />\r\n\t\r\n    <script type=\"text/javascript\"
+        src=\"/online-applications-skin/scripts/jquery.min.js\"></script>\r\n    <script
+        type=\"text/javascript\" src=\"/online-applications-skin/scripts/jquery.toolbar.idox.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/common.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/checkbox.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/amplify.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/createCommentCookie.js\"></script>\r\n
+        \       \r\n\t<!-- Customer Analytics Script -->\r\n\t\r\n\t\r\n    <script
+        type=\"text/javascript\">\r\n    \t$('html').addClass('js');\r\n    \t$(document).ready(function(){\r\n
+        \   \t\t$('.main#apply>span:first-child').attr('tabindex', '0')\r\n    \t});\r\n
+        \   </script>\r\n    \r\n    <!-- #BeginEditable \"mobile\" --><!-- #EndEditable
+        -->\r\n    <!-- #BeginEditable \"head\" -->\r\n\t<script type=\"text/javascript\">\r\n\t
+        \   jQuery(document).ready(function() {\t\r\n\t\t\tjQuery('#pa').before('<img
+        src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\" id=\"preload\"
+        />');\r\n\t\t\tjQuery('#preload').hide();\r\n\t\t\tjQuery('.tabs a#tab_documents').click(
+        function(event) {\r\n\t\t\t\t  window.clearTimeout(window.timeOutId);\r\n\t\t\t\t
+        \ window.timeOutId = window.setTimeout(function() {\r\n\t\t\t\t\t\tjQuery('.content').before('<div
+        id=\"overlay\"></div><div id=\"loading\"><div id=\"message\">Loading. Please
+        wait.... <img src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\"
+        height=\"19\" width=\"220\" style=\"background:#fff;\" /></div></div>');\r\n\t\t\t\t
+        \ },10);\r\n\t\t\t\t});\r\n\t\t\tjQuery('p.associateddocument a').click( function(event)
+        {\r\n\t\t\t\t  window.clearTimeout(window.timeOutId);\r\n\t\t\t\t  window.timeOutId
+        = window.setTimeout(function() {\r\n\t\t\t\t\t\tjQuery('.content').before('<div
+        id=\"overlay\"></div><div id=\"loading\"><div id=\"message\">Loading. Please
+        wait.... <img src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\"
+        height=\"19\" width=\"220\" style=\"background:#fff;\" /></div></div>');\r\n\t\t\t\t
+        \ },10);\r\n\t\t\t\t});\r\n\r\n\t\t});\r\n    </script>\r\n    \r\n    <link
+        rel=\"stylesheet\" href=\"/online-applications-skin/styles/simple_social_share.min.css\"
+        type=\"text/css\"/>\r\n    <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/simple_social_share.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\">\r\n        $(document).ready(function(){\r\n
+        \           \r\n            \r\n            $(\"share-button\").simpleSocialShare({\r\n
+        \               sites: \"twitter,email\", \r\n                url: window.location.href,
+        \r\n                title: \"Online application\", \r\n                description:
+        \"Please look at this Planning Application: \", \r\n                shareType:
+        \"button\", \r\n                buttonSide: \"left\", \r\n                orientation:
+        \"horizontal\"\r\n            });\r\n        });\r\n\t</script>\r\n\t<!--
+        #EndEditable -->\r\n    <!-- #BeginEditable \"webapp\" --><!-- #EndEditable
+        -->\r\n\r\n</head>\r\n<body>\r\n\r\n    <a href=\"#pageheading\" class=\"sr-only\">Skip
+        to main content</a>\r\n\r\n    <!-- IDOX PA START -->\r\n    <div id=\"idox\">\r\n
+        \       <div id=\"pa\">\r\n\t\t\t<div id=\"header\"><!-- Selector: Selector
+        1 -->\r\n<style>\r\n#langStyle{float:right; margin-top: 10px; margin-right:
+        30px; background:transparent; font-size:13px; cursor:pointer; border:1px solid
+        #fff !important;border-radius:2px; z-index:999; background-color: #fff; padding:2px;}\r\n#langStyle:hover{text-decoration:
+        underline;}</style>\r\n<div>\r\n\r\n<!--CYS--><a id=\"langStyle\" href=\"/online-applications/applicationDetails.do?keyVal=_CARDIFF_DCAPR_126508&activeTab=summary&lang=CY\">Cymraeg</a><!--CYE-->\r\n</div>\r\n\t\t\t\t<div
+        class=\"container\">\r\n\t\t\t\t\t<div id=\"logo\"><a href=\"https://www.cardiff.gov.uk/\"
+        title=\"Cardiff Council home page\"><img src=\"/online-applications-skin/images/cardiff/logo.png\"
+        alt=\"Council logo\" /><span class=\"sr-only\">Cardiff Council</span></a></div>\r\n\t\t\t\t\t<div
+        id=\"headertitle\"><span></span></div>\r\n\t\t\t\t\t<div class=\"clear\"></div>\r\n\t\t\t\t</div>\t\r\n\t\t\t</div>\r\n\t\t\t<div
+        id=\"breadcrumbs\" class=\"container\">\r\n\t\t\t\t<ul>\r\n\t\t\t\t\t\r\n\t\t\t\t</ul>\r\n\t\t\t</div>\r\n
+        \           <div class=\"container\">\r\n       \t\t\t<div id=\"toolbar\"
+        class=\"nojs\">\r\n                    <ul>\t\r\n                        <li
+        id=\"search\" class=\"main\"><span tabindex=\"0\">Search&nbsp;</span><span
+        class=\"caret\"></span>\r\n   \t\t\t\t\t\t\t<ul>\t\r\n\t\t\t\t\t\t\t\t<!--
+        #BeginLibraryItem \"/Library/searchModulesNavItems.lbi\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \       \r\n            <li id=\"planLinks\">\r\n                <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\"
+        >\r\n                    <span>Planning</span>\r\n                </a>\r\n
+        \               <ul>\r\n                    <li id=\"planBasicSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\">\r\n
+        \                           Simple Search\r\n                        </a>\r\n
+        \                   </li>\r\n\r\n                    <li id=\"planAdvancedSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=advanced&amp;searchType=Application\">\r\n
+        \                           Advanced\r\n                        </a>\r\n                    </li>\r\n
+        \                   <li id=\"planListSearch\">\r\n                        <a
+        href=\"/online-applications/search.do?action=weeklyList&amp;searchType=Application\">\r\n
+        \                           Weekly/Monthly Lists\r\n                        </a>\r\n
+        \                   </li>\r\n                    <li id=\"planPropertySearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=property&amp;type=custom\">\r\n
+        \                           Property Search\r\n                        </a>\r\n
+        \                   </li>\r\n\t\t\t\t\t\r\n                    \r\n\t\t\t\t\t\r\n
+        \               </ul>\r\n            </li>\r\n        \r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        <!-- #EndLibraryItem -->\r\n                        \t</ul>\r\n\t\t\t\t\t\t</li>\r\n
+        \                       <!-- #BeginEditable \"applicationForms\" -->\n\n\n\n\n\n
+        \  \n<!-- #EndEditable -->   \t\t\t\t\r\n                        <li id=\"myprofile\"
+        class=\"main\"><span tabindex=\"0\">My Profile&nbsp;</span><span class=\"caret\"></span>\r\n
+        \                           <ul>\r\n                              <!-- #BeginLibraryItem
+        \"/Library/consulteeInTrayNavItem.lbi\" -->\n\n\n\n\n\n\n    <!-- #EndLibraryItem
+        -->\r\n                                <li><a href=\"/online-applications/registered/displayUserDetails.do\">Profile
+        Details</a></li>\r\n                                <li><a href=\"/online-applications/registered/savedSearch.do?action=display\">Saved
+        Searches</a></li>\r\n                                <li><a href=\"/online-applications/registered/userAdmin.do?action=showNotifiedApplications\">Notified
+        Applications</a></li>\r\n                                <li><a href=\"/online-applications/registered/trackedApplication.do?action=display\">Tracked
+        Applications</a></li>\r\n                                <!-- #BeginEditable
+        \"formSubmissions\" -->\n\n\n\n\n\n\n\n\n<!-- #EndEditable -->    \t\r\n                            </ul>\r\n
+        \                       </li>\r\n                        <li id=\"loginLink\"
+        class=\"main\"><!-- #BeginEditable \"loginlogout\" -->\n\n\n\n\n\n\n\n\n\n\n\t<a
+        href=\"/online-applications/registered/userAdmin.do\">Login</a>\n<!-- #EndEditable
+        --></li>\r\n                        <!-- #BeginEditable \"register\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \  \r\n\r\n\r\n\t<li id=\"register\">\r\n        <a href=\"/online-applications/registrationWizard.do?action=start\">Register</a>\r\n\t</li>\r\n\r\n<!--
+        #EndEditable -->\r\n                        <!-- #BeginLibraryItem \"/Library/applyOnlineNavItems.lbi\"
+        -->\r\n\r\n\r\n\r\n\r\n\r\n<!-- #EndLibraryItem -->\r\n                    </ul>\r\n
+        \   \t\t\t</div>\r\n\r\n    \t\t\t<!-- #BeginEditable \"headlinenews\" --><!--
+        #EndEditable -->\r\n                 \r\n                <div id=\"pageheading\">\r\n
+        \                   <h1><strong>Planning</strong>&nbsp;&ndash;&nbsp;<!-- #BeginEditable
+        \"pageheading\" -->Application Summary<!-- #EndEditable --></h1>\r\n                    <!--
+        #BeginEditable \"helplink\" -->\r\n<p class=\"pagehelp\">\r\n\t<a title=\"Help
+        with this page (opens in a new window)\" rel=\"external\" target=\"_blank\"
+        href=\"/online-applications/help/pagehelp/applications.htm\">\r\n\t\tHelp
+        with this page\r\n\t<span> (opens in a new window)</span>\r\n\t</a>\r\n</p>\r\n<!--
+        #EndEditable -->\r\n                </div>\r\n                \r\n                <!--
+        START WAM CONTENT -->\r\n                <div class=\"content\">\r\n                    <!--
+        #BeginEditable \"errormsg\" -->\n        \n        \n\n        \n        \n
+        \   <!-- #EndEditable -->\r\n                    <!-- #BeginEditable \"pagehead\"
+        -->\r\n\r\n    <div class=\"addressCrumb\">\r\n        <span class=\"caseNumber\">\r\n
+        \           \r\n\r\n            \r\n                19/00263/DCH\r\n            \r\n
+        \       </span>\r\n\r\n        <span class=\"divider1\">|</span>\r\n\r\n        \r\n
+        \           <span class=\"description\">\r\n                VARIATION OF CONDITION
+        2 (APPROVED PLANS) OF 17/03122/DCH\r\n            </span>\r\n            \r\n
+        \               <span class=\"divider2\">|</span>\r\n            \r\n        \r\n\r\n
+        \       \r\n\r\n        \r\n\r\n        \r\n        \r\n        \r\n        \r\n
+        \       \r\n            \r\n            <span class=\"address\">\r\n                MILL
+        FARM HOUSE, MILL FARM, ST MELLONS ROAD, LISVANE, CARDIFF, CF14 0SH\r\n            </span>\r\n
+        \       \r\n        \r\n    </div>\r\n\r\n\r\n    <div id=\"applicationTools\">\r\n
+        \       <ul>\r\n            \r\n            \r\n                \r\n                    \r\n
+        \                       \r\n                            \r\n                            \r\n
+        \                               \r\n                                    <li>\r\n
+        \                                       <a href=\"/online-applications/searchResultsBack.do?action=back\"
+        id=\"searchresultsback\">Back to search results</a>\r\n                                    </li>\r\n
+        \                               \r\n                            \r\n                        \r\n
+        \                   \r\n                    \r\n                    \r\n                \r\n
+        \           \r\n\r\n            \r\n\r\n            \r\n            \r\n\r\n
+        \           \r\n\r\n            \r\n            \r\n                \r\n                    <li>\r\n
+        \                       <form name=\"trackForm\" method=\"post\" action=\"/online-applications/registered/trackedApplicationSubmit.do?action=track\"><input
+        type=\"hidden\" name=\"org.apache.struts.taglib.html.TOKEN\" value=\"3c629017e9862a4bf655e79fb35c4e80\"
+        />\r\n                            <input type=\"hidden\" name=\"caseNo\" value=\"19/00263/DCH\"
+        />\r\n                            <input type=\"hidden\" name=\"caseType\"
+        value=\"Application\" />\r\n                            <input type=\"hidden\"
+        name=\"address\" value=\"MILL FARM HOUSE, MILL FARM, ST MELLONS ROAD, LISVANE,
+        CARDIFF, CF14 0SH\" />\r\n                            <input type=\"hidden\"
+        name=\"description\" value=\"VARIATION OF CONDITION 2 (APPROVED PLANS) OF
+        17/03122/DCH\" />\r\n                            <input type=\"hidden\" name=\"status\"
+        value=\"Decided\" />\r\n                            <input type=\"hidden\"
+        name=\"trackingStatus\" value=\"Decided\" />\r\n                            <input
+        type=\"hidden\" name=\"caseTechnicalKey\" value=\"_CARDIFF_DCAPR_126508\"
+        />\r\n                            <input class=\"casefiletrack\"\r\n                                   src=\"/online-applications-skin/images/button_track.gif\"\r\n
+        \                                  type=\"image\"\r\n                                   name=\"submit\"\r\n
+        \                                  altKey=\"casedetails.track\"\r\n                                   title=\"Get
+        informed when this item is updated\"/>\r\n                        </form>\r\n
+        \                   </li>\r\n                \r\n\r\n                \r\n
+        \           \r\n\r\n\r\n            \r\n                \r\n             \r\n
+        \           \r\n\r\n            \r\n            \r\n                \r\n            \r\n
+        \           \r\n            \r\n            <li>\r\n                <a href=\"/online-applications/applicationDetails.do?activeTab=printPreview&amp;keyVal=_CARDIFF_DCAPR_126508\"
+        id=\"print\" rel=\"external\">\r\n                    <img src=\"/online-applications-skin/images/button_print.gif\"
+        alt=\"Print summary icon\" width=\"53\" height=\"22\" border=\"0\"/>\r\n                </a>\r\n
+        \           </li>\r\n            \r\n\r\n            \r\n        </ul>\r\n\r\n
+        \   </div>\r\n\r\n\r\n     \r\n\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabs\" -->\r\n    \r\n    <ul class=\"tabs\">\r\n\r\n        \r\n\r\n
+        \           \r\n                \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/applicationDetails.do?activeTab=summary&amp;keyVal=_CARDIFF_DCAPR_126508\"
+        id=\"tab_summary\" class=\"active\">\r\n                        <span>\r\n
+        \                           Details\r\n                            \r\n                        </span>\r\n
+        \                   </a>\r\n\r\n                    \r\n                    \r\n
+        \                   \r\n                        \r\n                        \r\n\r\n
+        \                           <ul class=\"subtabs\">\r\n                                \r\n
+        \                                   \r\n                                        <li>\r\n
+        \                                           \r\n                                            <a
+        href=\"/online-applications/applicationDetails.do?activeTab=summary&amp;keyVal=_CARDIFF_DCAPR_126508\"
+        id=\"subtab_summary\" class=\"active\">\r\n                                                <span>\r\n
+        \                                                   Summary\r\n                                                    \r\n
+        \                                               </span>\r\n                                            </a>\r\n
+        \                                       </li>\r\n                                    \r\n
+        \                               \r\n                                    \r\n
+        \                                       <li>\r\n                                            \r\n
+        \                                           <a href=\"/online-applications/applicationDetails.do?activeTab=details&amp;keyVal=_CARDIFF_DCAPR_126508\"
+        id=\"subtab_details\">\r\n                                                <span>\r\n
+        \                                                   Further Information\r\n
+        \                                                   \r\n                                                </span>\r\n
+        \                                           </a>\r\n                                        </li>\r\n
+        \                                   \r\n                                \r\n
+        \                                   \r\n                                        <li>\r\n
+        \                                           \r\n                                            <a
+        href=\"/online-applications/applicationDetails.do?activeTab=contacts&amp;keyVal=_CARDIFF_DCAPR_126508\"
+        id=\"subtab_contacts\">\r\n                                                <span>\r\n
+        \                                                   Contacts\r\n                                                    \r\n
+        \                                               </span>\r\n                                            </a>\r\n
+        \                                       </li>\r\n                                    \r\n
+        \                               \r\n                                    \r\n
+        \                                       <li>\r\n                                            \r\n
+        \                                           <a href=\"/online-applications/applicationDetails.do?activeTab=dates&amp;keyVal=_CARDIFF_DCAPR_126508\"
+        id=\"subtab_dates\">\r\n                                                <span>\r\n
+        \                                                   Important Dates\r\n                                                    \r\n
+        \                                               </span>\r\n                                            </a>\r\n
+        \                                       </li>\r\n                                    \r\n
+        \                               \r\n                            </ul>\r\n\r\n
+        \                       \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n                \r\n
+        \               <li>\r\n\r\n                     \r\n                    <a
+        href=\"/online-applications/applicationDetails.do?activeTab=makeComment&amp;keyVal=_CARDIFF_DCAPR_126508\"
+        id=\"tab_makeComment\">\r\n                        <span>\r\n                            Comments\r\n
+        \                           \r\n                                \r\n                                (0)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n\r\n
+        \           \r\n                <li class=\"nodocuments\">\r\n                    <span>\r\n
+        \                       Constraints\r\n                        \r\n                            \r\n
+        \                           (0)\r\n                        \r\n                    </span>\r\n
+        \               </li>\r\n            \r\n\r\n        \r\n\r\n            \r\n
+        \               \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/applicationDetails.do?activeTab=documents&amp;keyVal=_CARDIFF_DCAPR_126508\"
+        id=\"tab_documents\">\r\n                        <span>\r\n                            Documents\r\n
+        \                           \r\n                                \r\n                                (10)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n                \r\n
+        \               <li>\r\n\r\n                     \r\n                    <a
+        href=\"/online-applications/applicationDetails.do?activeTab=relatedCases&amp;keyVal=_CARDIFF_DCAPR_126508\"
+        id=\"tab_relatedCases\">\r\n                        <span>\r\n                            Related
+        Cases\r\n                            \r\n                                \r\n
+        \                               (2)\r\n                            \r\n                        </span>\r\n
+        \                   </a>\r\n\r\n                    \r\n                    \r\n
+        \                   \r\n                </li>\r\n            \r\n\r\n            \r\n\r\n
+        \       \r\n\r\n            \r\n\r\n            \r\n\r\n        \r\n    </ul>\r\n<!--
+        #EndEditable -->\r\n                    <!-- #BeginEditable \"tabsubnav\"
+        --><!-- #EndEditable -->\r\n                    <!-- #BeginEditable \"pagebody\"
+        -->\n    \r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\n
+        \   \n        \n        \n    \n\n    \n    \n    \n    \n    \n\n    <div
+        class=\"tabcontainer\">\n\n        \n        \n        \n\n        \n        \n\n
+        \           \n            \n                \n            \n\n            \n
+        \               <table id=\"simpleDetailsTable\" summary=\"Case Details\">\n\n
+        \                   \n                    \n                        \n                            <tr>\n
+        \                               <th scope=\"row\" width=\"40%\">\n                                    Reference\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            19/00263/DCH\n
+        \                                       \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Alternative Reference\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            PP-07614385\n
+        \                                       \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Application Received\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            Fri
+        08 Feb 2019\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Application Validated\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            Mon
+        11 Feb 2019\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Address\n                                </th>\n
+        \                               <td>\n                                    \n
+        \                                       \n                                        \n
+        \                                           MILL FARM HOUSE, MILL FARM, ST
+        MELLONS ROAD, LISVANE, CARDIFF, CF14 0SH\n                                        \n
+        \                                   \n                                </td>\n
+        \                           </tr>\n                        \n                    \n
+        \                       \n                            <tr>\n                                <th
+        scope=\"row\" width=\"40%\">\n                                    Proposal\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            VARIATION
+        OF CONDITION 2 (APPROVED PLANS) OF 17/03122/DCH\n                                        \n
+        \                                   \n                                </td>\n
+        \                           </tr>\n                        \n                    \n
+        \                       \n                            <tr>\n                                <th
+        scope=\"row\" width=\"40%\">\n                                    Status\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                           <span class=\"caseDetailsStatus\">Decided</span>\n
+        \                                       \n                                        \n
+        \                                   \n                                </td>\n
+        \                           </tr>\n                        \n                    \n
+        \                       \n                            <tr>\n                                <th
+        scope=\"row\" width=\"40%\">\n                                    Decision\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            Permission
+        be granted\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Decision Issued Date\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            Mon
+        08 Apr 2019\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Appeal Decision\n                                </th>\n
+        \                               <td>\n                                    \n
+        \                                       \n                                        \n
+        \                                           \n                                        \n
+        \                                   \n                                </td>\n
+        \                           </tr>\n                        \n                    \n\n
+        \               </table>\n\n                \n                \n\n                \n\n
+        \           \n\n            \n\n        \n\n        \n        \n            \n
+        \               <div id=\"summaryInfo\">\n                    \n                    \n
+        \                   \n                        \n                            \n
+        \                       \n                    \n\n                    \n                    \n
+        \                       <p class=\"associateddocument\">There are <a href=\"/online-applications/applicationDetails.do?activeTab=documents&amp;keyVal=_CARDIFF_DCAPR_126508\">10
+        documents</a> associated with this application.</p><p class=\"associatedcase\">There
+        is <a href=\"/online-applications/applicationDetails.do?activeTab=relatedCases&amp;keyVal=_CARDIFF_DCAPR_126508\">1
+        case</a> associated with this application.</p><p class=\"associatedproperty\">There
+        is <a href=\"/online-applications/applicationDetails.do?activeTab=relatedCases&amp;keyVal=_CARDIFF_DCAPR_126508\">1
+        property</a> associated with this application.</p>\r\n\n                    \n
+        \               </div>\n            \n        \n\n    </div>\n<!-- #EndEditable
+        -->\r\n                    <!-- #BeginEditable \"pagefoot\" --><!-- #EndEditable
+        -->\r\n                </div>\r\n                <!-- END WAM CONTENT -->\r\n
+        \               \r\n                <p id=\"poweredBy\"><a href=\"http://www.idoxgroup.com/\"
+        target=\"_blank\" title=\"This link will open a new window\"><img src=\"/online-applications-skin/images/idox.gif\"
+        alt=\"an Idox solution\" /></a></p>\r\n            </div>\t\r\n\t\t\t<div
+        id=\"footer\">\r\n\t\t\t\t<div class=\"container\">\t\t\t\t\t\r\n\t\t\t\t\t<div
+        id=\"links\">\r\n\t\t\t\t\t\t<ul>\r\n\t\t\t\t\t\t\t<li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Site_Map/Pages/default.aspx\">Site
+        map</a></li><li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Cookies/Pages/Cookies.aspx\">Cookies</a></li><li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/New_Disclaimer/Pages/default.aspx\">Disclaimer</a></li>\r\n\t\t\t\t\t\t</ul>\r\n\t\t\t\t\t</div>\r\n\t\t\t\t\t<div
+        class=\"clear\"></div>\r\n\t\t\t\t</div>\r\n\t\t\t</div>\r\n\t\t\t<div id=\"footerBottom\">\r\n\t\t\t
+        \   <div class=\"container\">\r\n\t\t\t        <div id=\"footercontent\"><p>&copy;
+        <script type=\"text/javascript\">document.write(new Date().getFullYear());</script>
+        Cardiff Council</p></div>\r\n\t\t\t        <div class=\"clear\"></div>\r\n\t\t\t
+        \   </div>\r\n\t\t\t</div>\r\n        </div>    \r\n    </div>  \r\n    <!--
+        IDOX PA END -->           \r\n\t\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Mon, 15 Apr 2019 11:15:04 GMT
+- request:
+    method: get
+    uri: https://planningonline.cardiff.gov.uk/online-applications/applicationDetails.do?activeTab=relatedCases&keyVal=_CARDIFF_DCAPR_126508
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip,deflate,identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mechanize/2.7.6 Ruby/2.6.2p47 (http://github.com/sparklemotion/mechanize/)
+      Accept-Charset:
+      - ISO-8859-1,utf-8;q=0.7,*;q=0.7
+      Accept-Language:
+      - en-us,en;q=0.5
+      Cookie:
+      - JSESSIONID=ss9pKoHL32yHmhJQONSykek96zXCSSZ75skxJ5v1.vmidoxweblve; WSLang-CFC001=EN
+      Host:
+      - planningonline.cardiff.gov.uk
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '300'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - text/html; charset=UTF-8
+      Expires:
+      - Mon, 15 Apr 2019 11:15:37 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ua-Compatible:
+      - IE=edge
+      Server:
+      - Apache
+      Set-Cookie:
+      - WSLang-CFC001=EN; expires=Mon, 15-Apr-2069 11:15:35 GMT; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 15 Apr 2019 11:15:37 GMT
+      Content-Length:
+      - '21444'
+    body:
+      encoding: UTF-8
+      string: "\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n<!DOCTYPE
+        html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\r\n<html
+        lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\r\n<head>\r\n\t\r\n\t<!--
+        #BeginEditable \"doctitle\" -->\r\n    <title>\r\n    19/00263/DCH\r\n    |\r\n
+        \   \r\n        VARIATION OF CONDITION 2 (APPROVED PLANS) OF 17/03122/DCH\r\n
+        \       \r\n        |\r\n        \r\n    \r\n\r\n    \r\n\r\n    \r\n\r\n
+        \   \r\n    \r\n    \r\n    \r\n    \r\n        \r\n        MILL FARM HOUSE,
+        MILL FARM, ST MELLONS ROAD, LISVANE, CARDIFF, CF14 0SH\r\n    \r\n    \r\n
+        \   </title>\r\n<!-- #EndEditable -->\r\n    <!-- #BeginEditable \"metatags\"
+        --><!-- #EndEditable -->\r\n\t\r\n    <meta http-equiv=\"Content-Type\" content=\"text/html;
+        charset=UTF-8\" />\r\n\t\r\n\t<!-- Customer metatags -->\r\n\t\r\n\t\r\n\t<!--
+        Favicon link -->\r\n    <link rel=\"icon\" href=\"/online-applications-skin/images/cardiff/favicon.ico\"
+        type=\"image/x-icon\" />\r\n\t\r\n    <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/screen.css\"
+        type=\"text/css\" media=\"screen,projection\" />\r\n    <link rel=\"stylesheet\"
+        href=\"/online-applications-skin/styles/theme1.css\" type=\"text/css\"/>    \r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/print.css\"
+        type=\"text/css\" media=\"print\" />\r\n\t\r\n    <script type=\"text/javascript\"
+        src=\"/online-applications-skin/scripts/jquery.min.js\"></script>\r\n    <script
+        type=\"text/javascript\" src=\"/online-applications-skin/scripts/jquery.toolbar.idox.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/common.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/checkbox.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/amplify.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/createCommentCookie.js\"></script>\r\n
+        \       \r\n\t<!-- Customer Analytics Script -->\r\n\t\r\n\t\r\n    <script
+        type=\"text/javascript\">\r\n    \t$('html').addClass('js');\r\n    \t$(document).ready(function(){\r\n
+        \   \t\t$('.main#apply>span:first-child').attr('tabindex', '0')\r\n    \t});\r\n
+        \   </script>\r\n    \r\n    <!-- #BeginEditable \"mobile\" --><!-- #EndEditable
+        -->\r\n    <!-- #BeginEditable \"head\" --><!-- #EndEditable -->\r\n    <!--
+        #BeginEditable \"webapp\" -->\r\n\t<script type=\"text/javascript\">\r\n\t
+        \   jQuery(document).ready(function() {\t\t\r\n\t\t\tjQuery('#pa').before('<img
+        src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\" id=\"preload\"
+        />');\r\n\t\t\tjQuery('#preload').hide();\r\n\t\t\tjQuery('.tabs a#tab_documents').click(
+        function(event) {\r\n\t\t\t\t  window.clearTimeout(window.timeOutId);\r\n\t\t\t\t
+        \ window.timeOutId = window.setTimeout(function() {\r\n\t\t\t\t\t\tjQuery('.content').before('<div
+        id=\"overlay\"></div><div id=\"loading\"><div id=\"message\">Loading. Please
+        wait.... <img src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\"
+        height=\"19\" width=\"220\" style=\"background:#fff;\" /></div></div>');\r\n\t\t\t\t
+        \ },10); \r\n\t\t\t\t});\r\n\t\t\t\t\r\n\t\t});\r\n\t</script>\r\n            \r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/simple_social_share.min.css\"
+        type=\"text/css\"/>\r\n    <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/simple_social_share.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\">\r\n        $(document).ready(function(){\r\n
+        \           \r\n            \r\n            $(\"share-button\").simpleSocialShare({\r\n
+        \               sites: \"twitter,email\", \r\n                url: window.location.href,
+        \r\n                title: \"Online application\", \r\n                description:
+        \"Please look at this Planning Application: \", \r\n                shareType:
+        \"button\", \r\n                buttonSide: \"left\", \r\n                orientation:
+        \"horizontal\"\r\n            });\r\n        });\r\n\t</script>\r\n\t<!--
+        #EndEditable -->\r\n\r\n</head>\r\n<body>\r\n\r\n    <a href=\"#pageheading\"
+        class=\"sr-only\">Skip to main content</a>\r\n\r\n    <!-- IDOX PA START -->\r\n
+        \   <div id=\"idox\">\r\n        <div id=\"pa\">\r\n\t\t\t<div id=\"header\"><!--
+        Selector: Selector 1 -->\r\n<style>\r\n#langStyle{float:right; margin-top:
+        10px; margin-right: 30px; background:transparent; font-size:13px; cursor:pointer;
+        border:1px solid #fff !important;border-radius:2px; z-index:999; background-color:
+        #fff; padding:2px;}\r\n#langStyle:hover{text-decoration: underline;}</style>\r\n<div>\r\n\r\n<!--CYS--><a
+        id=\"langStyle\" href=\"/online-applications/applicationDetails.do?activeTab=relatedCases&keyVal=_CARDIFF_DCAPR_126508&lang=CY\">Cymraeg</a><!--CYE-->\r\n</div>\r\n\t\t\t\t<div
+        class=\"container\">\r\n\t\t\t\t\t<div id=\"logo\"><a href=\"https://www.cardiff.gov.uk/\"
+        title=\"Cardiff Council home page\"><img src=\"/online-applications-skin/images/cardiff/logo.png\"
+        alt=\"Council logo\" /><span class=\"sr-only\">Cardiff Council</span></a></div>\r\n\t\t\t\t\t<div
+        id=\"headertitle\"><span></span></div>\r\n\t\t\t\t\t<div class=\"clear\"></div>\r\n\t\t\t\t</div>\t\r\n\t\t\t</div>\r\n\t\t\t<div
+        id=\"breadcrumbs\" class=\"container\">\r\n\t\t\t\t<ul>\r\n\t\t\t\t\t\r\n\t\t\t\t</ul>\r\n\t\t\t</div>\r\n
+        \           <div class=\"container\">\r\n       \t\t\t<div id=\"toolbar\"
+        class=\"nojs\">\r\n                    <ul>\t\r\n                        <li
+        id=\"search\" class=\"main\"><span tabindex=\"0\">Search&nbsp;</span><span
+        class=\"caret\"></span>\r\n   \t\t\t\t\t\t\t<ul>\t\r\n\t\t\t\t\t\t\t\t<!--
+        #BeginLibraryItem \"/Library/searchModulesNavItems.lbi\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \       \r\n            <li id=\"planLinks\">\r\n                <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\"
+        >\r\n                    <span>Planning</span>\r\n                </a>\r\n
+        \               <ul>\r\n                    <li id=\"planBasicSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\">\r\n
+        \                           Simple Search\r\n                        </a>\r\n
+        \                   </li>\r\n\r\n                    <li id=\"planAdvancedSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=advanced&amp;searchType=Application\">\r\n
+        \                           Advanced\r\n                        </a>\r\n                    </li>\r\n
+        \                   <li id=\"planListSearch\">\r\n                        <a
+        href=\"/online-applications/search.do?action=weeklyList&amp;searchType=Application\">\r\n
+        \                           Weekly/Monthly Lists\r\n                        </a>\r\n
+        \                   </li>\r\n                    <li id=\"planPropertySearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=property&amp;type=custom\">\r\n
+        \                           Property Search\r\n                        </a>\r\n
+        \                   </li>\r\n\t\t\t\t\t\r\n                    \r\n\t\t\t\t\t\r\n
+        \               </ul>\r\n            </li>\r\n        \r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        <!-- #EndLibraryItem -->\r\n                        \t</ul>\r\n\t\t\t\t\t\t</li>\r\n
+        \                       <!-- #BeginEditable \"applicationForms\" -->\n\n\n\n\n\n
+        \  \n<!-- #EndEditable -->   \t\t\t\t\r\n                        <li id=\"myprofile\"
+        class=\"main\"><span tabindex=\"0\">My Profile&nbsp;</span><span class=\"caret\"></span>\r\n
+        \                           <ul>\r\n                              <!-- #BeginLibraryItem
+        \"/Library/consulteeInTrayNavItem.lbi\" -->\n\n\n\n\n\n\n    <!-- #EndLibraryItem
+        -->\r\n                                <li><a href=\"/online-applications/registered/displayUserDetails.do\">Profile
+        Details</a></li>\r\n                                <li><a href=\"/online-applications/registered/savedSearch.do?action=display\">Saved
+        Searches</a></li>\r\n                                <li><a href=\"/online-applications/registered/userAdmin.do?action=showNotifiedApplications\">Notified
+        Applications</a></li>\r\n                                <li><a href=\"/online-applications/registered/trackedApplication.do?action=display\">Tracked
+        Applications</a></li>\r\n                                <!-- #BeginEditable
+        \"formSubmissions\" -->\n\n\n\n\n\n\n\n\n<!-- #EndEditable -->    \t\r\n                            </ul>\r\n
+        \                       </li>\r\n                        <li id=\"loginLink\"
+        class=\"main\"><!-- #BeginEditable \"loginlogout\" -->\n\n\n\n\n\n\n\n\n\n\n\t<a
+        href=\"/online-applications/registered/userAdmin.do\">Login</a>\n<!-- #EndEditable
+        --></li>\r\n                        <!-- #BeginEditable \"register\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \  \r\n\r\n\r\n\t<li id=\"register\">\r\n        <a href=\"/online-applications/registrationWizard.do?action=start\">Register</a>\r\n\t</li>\r\n\r\n<!--
+        #EndEditable -->\r\n                        <!-- #BeginLibraryItem \"/Library/applyOnlineNavItems.lbi\"
+        -->\r\n\r\n\r\n\r\n\r\n\r\n<!-- #EndLibraryItem -->\r\n                    </ul>\r\n
+        \   \t\t\t</div>\r\n\r\n    \t\t\t<!-- #BeginEditable \"headlinenews\" --><!--
+        #EndEditable -->\r\n                 \r\n                <div id=\"pageheading\">\r\n
+        \                   <h1><strong>Planning</strong>&nbsp;&ndash;&nbsp;<!-- #BeginEditable
+        \"pageheading\" -->Application Related Items<!-- #EndEditable --></h1>\r\n
+        \                   <!-- #BeginEditable \"helplink\" -->\r\n<p class=\"pagehelp\">\r\n\t<a
+        title=\"Help with this page (opens in a new window)\" rel=\"external\" target=\"_blank\"
+        href=\"/online-applications/help/pagehelp/applications.htm\">\r\n\t\tHelp
+        with this page\r\n\t<span> (opens in a new window)</span>\r\n\t</a>\r\n</p>\r\n<!--
+        #EndEditable -->\r\n                </div>\r\n                \r\n                <!--
+        START WAM CONTENT -->\r\n                <div class=\"content\">\r\n                    <!--
+        #BeginEditable \"errormsg\" --><!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"pagehead\" -->\r\n\r\n    <div class=\"addressCrumb\">\r\n
+        \       <span class=\"caseNumber\">\r\n            \r\n\r\n            \r\n
+        \               19/00263/DCH\r\n            \r\n        </span>\r\n\r\n        <span
+        class=\"divider1\">|</span>\r\n\r\n        \r\n            <span class=\"description\">\r\n
+        \               VARIATION OF CONDITION 2 (APPROVED PLANS) OF 17/03122/DCH\r\n
+        \           </span>\r\n            \r\n                <span class=\"divider2\">|</span>\r\n
+        \           \r\n        \r\n\r\n        \r\n\r\n        \r\n\r\n        \r\n
+        \       \r\n        \r\n        \r\n        \r\n            \r\n            <span
+        class=\"address\">\r\n                MILL FARM HOUSE, MILL FARM, ST MELLONS
+        ROAD, LISVANE, CARDIFF, CF14 0SH\r\n            </span>\r\n        \r\n        \r\n
+        \   </div>\r\n\r\n\r\n    <div id=\"applicationTools\">\r\n        <ul>\r\n
+        \           \r\n            \r\n                \r\n                    \r\n
+        \                       \r\n                            \r\n                            \r\n
+        \                               \r\n                                    <li>\r\n
+        \                                       <a href=\"/online-applications/searchResultsBack.do?action=back\"
+        id=\"searchresultsback\">Back to search results</a>\r\n                                    </li>\r\n
+        \                               \r\n                            \r\n                        \r\n
+        \                   \r\n                    \r\n                    \r\n                \r\n
+        \           \r\n\r\n            \r\n\r\n            \r\n            \r\n\r\n
+        \           \r\n\r\n            \r\n            \r\n                \r\n                    <li>\r\n
+        \                       <form name=\"trackForm\" method=\"post\" action=\"/online-applications/registered/trackedApplicationSubmit.do?action=track\"><input
+        type=\"hidden\" name=\"org.apache.struts.taglib.html.TOKEN\" value=\"3c629017e9862a4bf655e79fb35c4e80\"
+        />\r\n                            <input type=\"hidden\" name=\"caseNo\" value=\"19/00263/DCH\"
+        />\r\n                            <input type=\"hidden\" name=\"caseType\"
+        value=\"Application\" />\r\n                            <input type=\"hidden\"
+        name=\"address\" value=\"MILL FARM HOUSE, MILL FARM, ST MELLONS ROAD, LISVANE,
+        CARDIFF, CF14 0SH\" />\r\n                            <input type=\"hidden\"
+        name=\"description\" value=\"VARIATION OF CONDITION 2 (APPROVED PLANS) OF
+        17/03122/DCH\" />\r\n                            <input type=\"hidden\" name=\"status\"
+        value=\"Decided\" />\r\n                            <input type=\"hidden\"
+        name=\"trackingStatus\" value=\"Decided\" />\r\n                            <input
+        type=\"hidden\" name=\"caseTechnicalKey\" value=\"_CARDIFF_DCAPR_126508\"
+        />\r\n                            <input class=\"casefiletrack\"\r\n                                   src=\"/online-applications-skin/images/button_track.gif\"\r\n
+        \                                  type=\"image\"\r\n                                   name=\"submit\"\r\n
+        \                                  altKey=\"casedetails.track\"\r\n                                   title=\"Get
+        informed when this item is updated\"/>\r\n                        </form>\r\n
+        \                   </li>\r\n                \r\n\r\n                \r\n
+        \           \r\n\r\n\r\n            \r\n                \r\n             \r\n
+        \           \r\n\r\n            \r\n            \r\n                \r\n            \r\n
+        \           \r\n            \r\n            <li>\r\n                <a href=\"/online-applications/applicationDetails.do?activeTab=printPreview&amp;keyVal=_CARDIFF_DCAPR_126508\"
+        id=\"print\" rel=\"external\">\r\n                    <img src=\"/online-applications-skin/images/button_print.gif\"
+        alt=\"Print summary icon\" width=\"53\" height=\"22\" border=\"0\"/>\r\n                </a>\r\n
+        \           </li>\r\n            \r\n\r\n            \r\n        </ul>\r\n\r\n
+        \   </div>\r\n\r\n\r\n     \r\n\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabs\" -->\r\n    \r\n    <ul class=\"tabs\">\r\n\r\n        \r\n\r\n
+        \           \r\n                \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/applicationDetails.do?activeTab=summary&amp;keyVal=_CARDIFF_DCAPR_126508\"
+        id=\"tab_summary\">\r\n                        <span>\r\n                            Details\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n                \r\n
+        \               <li>\r\n\r\n                     \r\n                    <a
+        href=\"/online-applications/applicationDetails.do?activeTab=makeComment&amp;keyVal=_CARDIFF_DCAPR_126508\"
+        id=\"tab_makeComment\">\r\n                        <span>\r\n                            Comments\r\n
+        \                           \r\n                                \r\n                                (0)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n\r\n
+        \           \r\n                <li class=\"nodocuments\">\r\n                    <span>\r\n
+        \                       Constraints\r\n                        \r\n                            \r\n
+        \                           (0)\r\n                        \r\n                    </span>\r\n
+        \               </li>\r\n            \r\n\r\n        \r\n\r\n            \r\n
+        \               \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/applicationDetails.do?activeTab=documents&amp;keyVal=_CARDIFF_DCAPR_126508\"
+        id=\"tab_documents\">\r\n                        <span>\r\n                            Documents\r\n
+        \                           \r\n                                \r\n                                (10)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n                \r\n
+        \               <li>\r\n\r\n                     \r\n                    <a
+        href=\"/online-applications/applicationDetails.do?activeTab=relatedCases&amp;keyVal=_CARDIFF_DCAPR_126508\"
+        id=\"tab_relatedCases\" class=\"active\">\r\n                        <span>\r\n
+        \                           Related Cases\r\n                            \r\n
+        \                               \r\n                                (2)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                        \r\n
+        \                       \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n\r\n
+        \           \r\n\r\n        \r\n    </ul>\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabsubnav\" --><!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"pagebody\" -->\r\n\r\n    \r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \   <div class=\"tabcontainer toplevel\">\r\n    <div id=\"relatedItems\">\r\n\r\n
+        \       \r\n            \r\n            \r\n\r\n            <!-- Display header
+        -->\r\n            <div id=\"Application\">\r\n                <h3>\r\n                    \r\n
+        \                   \r\n                        Planning Applications\r\n
+        \                   \r\n                    <span>(1)</span>\r\n                </h3>\n\r\n\r\n
+        \               <!-- Display each item -->\r\n                \r\n                    <ul>\r\n
+        \                       \r\n                            <li>\r\n                                \r\n
+        \                               \r\n                                \r\n\r\n
+        \                               <a href=\"/online-applications/applicationDetails.do?previousCaseType=Application&amp;keyVal=_CARDIFF_DCAPR_122381&amp;previousCaseNumber=19%2F00263%2FDCH&amp;activeTab=summary&amp;previousKeyVal=_CARDIFF_DCAPR_126508\">\r\n
+        \                                   DEMOLITION OF EXISTING REAR AND SIDE EXTENSION.
+        PROPOSED NEW SINGLE STOREY REAR EXTENSION WITH RO...\r\n                                </a>\r\n\r\n
+        \                               <p class=\"metaInfo\">\r\n\r\n                                \r\n\r\n
+        \                               \r\n\r\n                                \r\n
+        \                                   <span class=\"metaInfo\">\r\n                                        Ref.
+        No:\r\n                                        17/03122/DCH\r\n                                        <span
+        class=\"divider\">|</span>\r\n                                        Status:\r\n
+        \                                       Decided\r\n                                    </span>\r\n
+        \                               \r\n                                \r\n                                \r\n
+        \                              </p>\r\n                            </li>\r\n
+        \                       \r\n                    </ul>\r\n                \r\n
+        \           </div>\r\n\r\n        \r\n            \r\n            \r\n\r\n
+        \           <!-- Display header -->\r\n            <div id=\"Appeal\">\r\n
+        \               <h3>\r\n                    \r\n                    \r\n                        Planning
+        Appeals\r\n                    \r\n                    <span>(0)</span>\r\n
+        \               </h3>\n\r\n\r\n                <!-- Display each item -->\r\n
+        \               \r\n            </div>\r\n\r\n        \r\n            \r\n
+        \           \r\n\r\n            <!-- Display header -->\r\n            <div
+        id=\"Enforcement\">\r\n                <h3>\r\n                    \r\n                    \r\n
+        \                       Planning Enforcements\r\n                    \r\n
+        \                   <span>(0)</span>\r\n                </h3>\n\r\n\r\n                <!--
+        Display each item -->\r\n                \r\n            </div>\r\n\r\n        \r\n
+        \           \r\n            \r\n\r\n            <!-- Display header -->\r\n
+        \           <div id=\"Property\">\r\n                <h3>\r\n                    \r\n
+        \                   \r\n                        Properties\r\n                    \r\n
+        \                   <span>(1)</span>\r\n                </h3>\n\r\n\r\n                <!--
+        Display each item -->\r\n                \r\n                    <ul>\r\n
+        \                       \r\n                            <li>\r\n                                \r\n
+        \                               \r\n                                \r\n\r\n
+        \                               <a href=\"/online-applications/propertyDetails.do?previousCaseType=Application&amp;keyVal=_CARDIFF_PROPLPI_366211_2&amp;previousCaseNumber=19%2F00263%2FDCH&amp;activeTab=summary&amp;previousKeyVal=_CARDIFF_DCAPR_126508\">\r\n
+        \                                   MILL FARM HOUSE, MILL FARM, ST MELLONS
+        ROAD, LISVANE, CARDIFF, CF14 0SH\r\n                                </a>\r\n\r\n
+        \                               <p class=\"metaInfo\">\r\n\r\n                                \r\n\r\n
+        \                               \r\n\r\n                                \r\n
+        \                               \r\n                                \r\n                               </p>\r\n
+        \                           </li>\r\n                        \r\n                    </ul>\r\n
+        \               \r\n            </div>\r\n\r\n        \r\n\r\n    </div>\r\n
+        \   </div>\r\n\r\n<!-- #EndEditable -->\r\n                    <!-- #BeginEditable
+        \"pagefoot\" --><!-- #EndEditable -->\r\n                </div>\r\n                <!--
+        END WAM CONTENT -->\r\n                \r\n                <p id=\"poweredBy\"><a
+        href=\"http://www.idoxgroup.com/\" target=\"_blank\" title=\"This link will
+        open a new window\"><img src=\"/online-applications-skin/images/idox.gif\"
+        alt=\"an Idox solution\" /></a></p>\r\n            </div>\t\r\n\t\t\t<div
+        id=\"footer\">\r\n\t\t\t\t<div class=\"container\">\t\t\t\t\t\r\n\t\t\t\t\t<div
+        id=\"links\">\r\n\t\t\t\t\t\t<ul>\r\n\t\t\t\t\t\t\t<li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Site_Map/Pages/default.aspx\">Site
+        map</a></li><li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Cookies/Pages/Cookies.aspx\">Cookies</a></li><li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/New_Disclaimer/Pages/default.aspx\">Disclaimer</a></li>\r\n\t\t\t\t\t\t</ul>\r\n\t\t\t\t\t</div>\r\n\t\t\t\t\t<div
+        class=\"clear\"></div>\r\n\t\t\t\t</div>\r\n\t\t\t</div>\r\n\t\t\t<div id=\"footerBottom\">\r\n\t\t\t
+        \   <div class=\"container\">\r\n\t\t\t        <div id=\"footercontent\"><p>&copy;
+        <script type=\"text/javascript\">document.write(new Date().getFullYear());</script>
+        Cardiff Council</p></div>\r\n\t\t\t        <div class=\"clear\"></div>\r\n\t\t\t
+        \   </div>\r\n\t\t\t</div>\r\n        </div>    \r\n    </div>  \r\n    <!--
+        IDOX PA END -->           \r\n\t\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Mon, 15 Apr 2019 11:15:06 GMT
+- request:
+    method: get
+    uri: https://planningonline.cardiff.gov.uk/online-applications/propertyDetails.do?activeTab=summary&keyVal=_CARDIFF_PROPLPI_366211_2&previousCaseNumber=19/00263/DCH&previousCaseType=Application&previousKeyVal=_CARDIFF_DCAPR_126508
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip,deflate,identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mechanize/2.7.6 Ruby/2.6.2p47 (http://github.com/sparklemotion/mechanize/)
+      Accept-Charset:
+      - ISO-8859-1,utf-8;q=0.7,*;q=0.7
+      Accept-Language:
+      - en-us,en;q=0.5
+      Cookie:
+      - JSESSIONID=ss9pKoHL32yHmhJQONSykek96zXCSSZ75skxJ5v1.vmidoxweblve; WSLang-CFC001=EN
+      Host:
+      - planningonline.cardiff.gov.uk
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '300'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - text/html; charset=UTF-8
+      Expires:
+      - Mon, 15 Apr 2019 11:15:39 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ua-Compatible:
+      - IE=edge
+      Server:
+      - Apache
+      Set-Cookie:
+      - WSLang-CFC001=EN; expires=Mon, 15-Apr-2069 11:15:37 GMT; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 15 Apr 2019 11:15:39 GMT
+      Content-Length:
+      - '13660'
+    body:
+      encoding: UTF-8
+      string: "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n    \n\n    \n\n<!DOCTYPE html PUBLIC
+        \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\r\n<html
+        lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\r\n<head>\r\n\r\n\t<!--
+        #BeginEditable \"doctitle\" -->\r\n    <title>\r\n    _CARDIFF_PROPLPI_366211_2\r\n
+        \   |\r\n    \r\n\r\n    \r\n\r\n    \r\n\r\n    \r\n    \r\n    \r\n    \r\n
+        \   \r\n        \r\n        MILL FARM HOUSE, MILL FARM, ST MELLONS ROAD, LISVANE,
+        CARDIFF, CF14 0SH\r\n    \r\n    \r\n    </title>\r\n<!-- #EndEditable -->\r\n
+        \   <!-- #BeginEditable \"metatags\" --><!-- #EndEditable -->\r\n\t\r\n    <meta
+        http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" />\r\n\t\r\n\t<!--
+        Customer metatags -->\r\n\t\r\n\t\r\n\t<!-- Favicon link -->\r\n    <link
+        rel=\"icon\" href=\"/online-applications-skin/images/cardiff/favicon.ico\"
+        type=\"image/x-icon\" />\r\n\t\r\n    <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/screen.css\"
+        type=\"text/css\" media=\"screen,projection\" />\r\n    <link rel=\"stylesheet\"
+        href=\"/online-applications-skin/styles/theme1.css\" type=\"text/css\"/>\t\r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/print.css\"
+        type=\"text/css\" media=\"print\" />   \r\n\r\n    <script type=\"text/javascript\"
+        src=\"/online-applications-skin/scripts/jquery.min.js\"></script>\r\n    <script
+        type=\"text/javascript\" src=\"/online-applications-skin/scripts/jquery.toolbar.idox.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/common.js\"></script>\r\n
+        \       \r\n\t<!-- Customer Analytics Script -->\r\n\t\r\n\t\r\n    <script
+        type=\"text/javascript\">\r\n    \t$('html').addClass('js');\r\n    \t$(document).ready(function(){\r\n
+        \   \t\t$('.main#apply>span:first-child').attr('tabindex', '0')\r\n    \t});\r\n
+        \   </script>\r\n    \r\n    <!-- #BeginEditable \"mobile\" --><!-- #EndEditable
+        -->\r\n    <!-- #BeginEditable \"head\" --><!-- #EndEditable -->\r\n    <!--
+        #BeginEditable \"webapp\" --><!-- #EndEditable -->\r\n\r\n</head>\r\n<body>\r\n\r\n
+        \   <a href=\"#pageheading\" class=\"sr-only\">Skip to main content</a>\r\n\r\n
+        \   <!-- IDOX PA START -->\r\n    <div id=\"idox\">\r\n        <div id=\"pa\">
+        \r\n\t\t\t<div id=\"header\"><!-- Selector: Selector 1 -->\r\n<style>\r\n#langStyle{float:right;
+        margin-top: 10px; margin-right: 30px; background:transparent; font-size:13px;
+        cursor:pointer; border:1px solid #fff !important;border-radius:2px; z-index:999;
+        background-color: #fff; padding:2px;}\r\n#langStyle:hover{text-decoration:
+        underline;}</style>\r\n<div>\r\n\r\n<!--CYS--><a id=\"langStyle\" href=\"/online-applications/propertyDetails.do?previousCaseType=Application&keyVal=_CARDIFF_PROPLPI_366211_2&previousCaseNumber=19%2f00263%2fDCH&activeTab=summary&previousKeyVal=_CARDIFF_DCAPR_126508&lang=CY\">Cymraeg</a><!--CYE-->\r\n</div>\r\n\t\t\t\t<div
+        class=\"container\">\r\n\t\t\t\t\t<div id=\"logo\"><a href=\"https://www.cardiff.gov.uk/\"
+        title=\"Cardiff Council home page\"><img src=\"/online-applications-skin/images/cardiff/logo.png\"
+        alt=\"Council logo\" /><span class=\"sr-only\">Cardiff Council</span></a></div>\r\n\t\t\t\t\t<div
+        id=\"headertitle\"><span></span></div>\r\n\t\t\t\t\t<div class=\"clear\"></div>\r\n\t\t\t\t</div>\t\r\n\t\t\t</div>\r\n\t\t\t<div
+        id=\"breadcrumbs\" class=\"container\">\r\n\t\t\t\t<ul>\r\n\t\t\t\t\t\r\n\t\t\t\t</ul>\r\n\t\t\t</div>\r\n
+        \           <div class=\"container\">\r\n                <div id=\"toolbar\"
+        class=\"nojs\">\r\n                    <ul>\t\r\n                        <li
+        id=\"search\" class=\"main\"><span tabindex=\"0\">Search&nbsp;</span><span
+        class=\"caret\"></span>\r\n   \t\t\t\t\t\t\t<ul>\t\r\n\t\t\t\t\t\t\t\t<!--
+        #BeginLibraryItem \"/Library/searchModulesNavItems.lbi\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \       \r\n            <li id=\"planLinks\">\r\n                <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\"
+        >\r\n                    <span>Planning</span>\r\n                </a>\r\n
+        \               <ul>\r\n                    <li id=\"planBasicSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\">\r\n
+        \                           Simple Search\r\n                        </a>\r\n
+        \                   </li>\r\n\r\n                    <li id=\"planAdvancedSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=advanced&amp;searchType=Application\">\r\n
+        \                           Advanced\r\n                        </a>\r\n                    </li>\r\n
+        \                   <li id=\"planListSearch\">\r\n                        <a
+        href=\"/online-applications/search.do?action=weeklyList&amp;searchType=Application\">\r\n
+        \                           Weekly/Monthly Lists\r\n                        </a>\r\n
+        \                   </li>\r\n                    <li id=\"planPropertySearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=property&amp;type=custom\">\r\n
+        \                           Property Search\r\n                        </a>\r\n
+        \                   </li>\r\n\t\t\t\t\t\r\n                    \r\n\t\t\t\t\t\r\n
+        \               </ul>\r\n            </li>\r\n        \r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        <!-- #EndLibraryItem -->\r\n                        \t</ul>\r\n\t\t\t\t\t\t</li>\r\n
+        \                       <!-- #BeginEditable \"applicationForms\" -->\n\n\n\n\n\n
+        \  \n<!-- #EndEditable -->   \t\t\t\t\r\n                        <li id=\"myprofile\"
+        class=\"main\"><span tabindex=\"0\">My Profile&nbsp;</span><span class=\"caret\"></span>\r\n
+        \                           <ul>\r\n                              <!-- #BeginLibraryItem
+        \"/Library/consulteeInTrayNavItem.lbi\" -->\n\n\n\n\n\n\n    <!-- #EndLibraryItem
+        -->\r\n                                <li><a href=\"/online-applications/registered/displayUserDetails.do\">Profile
+        Details</a></li>\r\n                                <li><a href=\"/online-applications/registered/savedSearch.do?action=display\">Saved
+        Searches</a></li>\r\n                                <li><a href=\"/online-applications/registered/userAdmin.do?action=showNotifiedApplications\">Notified
+        Applications</a></li>\r\n                                <li><a href=\"/online-applications/registered/trackedApplication.do?action=display\">Tracked
+        Applications</a></li>\r\n                                <!-- #BeginEditable
+        \"formSubmissions\" -->\n\n\n\n\n\n\n\n\n<!-- #EndEditable -->    \t\r\n                            </ul>\r\n
+        \                       </li>\r\n                        <li id=\"loginLink\"
+        class=\"main\"><!-- #BeginEditable \"loginlogout\" -->\n\n\n\n\n\n\n\n\n\n\n\t<a
+        href=\"/online-applications/registered/userAdmin.do\">Login</a>\n<!-- #EndEditable
+        --></li>\r\n                        <!-- #BeginEditable \"register\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \  \r\n\r\n\r\n\t<li id=\"register\">\r\n        <a href=\"/online-applications/registrationWizard.do?action=start\">Register</a>\r\n\t</li>\r\n\r\n<!--
+        #EndEditable -->\r\n                        <!-- #BeginLibraryItem \"/Library/applyOnlineNavItems.lbi\"
+        -->\r\n\r\n\r\n\r\n\r\n\r\n<!-- #EndLibraryItem -->\r\n                    </ul>\r\n
+        \   \t\t\t</div>\r\n                \r\n                <div id=\"pageheading\">\r\n
+        \                   <h1><!-- #BeginEditable \"pageheading\" -->Property Address<!--
+        #EndEditable --></h1>\r\n                    <!-- #BeginEditable \"helplink\"
+        -->\r\n<p class=\"pagehelp\">\r\n\t<a title=\"Help with this page (opens in
+        a new window)\" rel=\"external\" target=\"_blank\" href=\"/online-applications/help/pagehelp/properties.htm\">\r\n\t\tHelp
+        with this page\r\n\t<span> (opens in a new window)</span>\r\n\t</a>\r\n</p>\r\n<!--
+        #EndEditable -->\r\n                </div>\r\n        \r\n                <!--
+        START WAM CONTENT -->\r\n                <div class=\"content\">\r\n                    <!--
+        #BeginEditable \"errormsg\" -->\n        \n        \n\n        \n        \n
+        \   <!-- #EndEditable -->\r\n                    <!-- #BeginEditable \"pagehead\"
+        -->\r\n\r\n    <div class=\"addressCrumb\">\r\n        <span class=\"caseNumber\">\r\n
+        \           \r\n                10023549353 \r\n            \r\n\r\n            \r\n
+        \       </span>\r\n\r\n        <span class=\"divider1\">|</span>\r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        \r\n\r\n        \r\n        \r\n        \r\n        \r\n
+        \       \r\n            \r\n            <span class=\"address\">\r\n                MILL
+        FARM HOUSE, MILL FARM, ST MELLONS ROAD, LISVANE, CARDIFF, CF14 0SH\r\n            </span>\r\n
+        \       \r\n        \r\n    </div>\r\n\r\n\r\n    <div id=\"applicationTools\">\r\n
+        \       <ul>\r\n            \r\n            \r\n\r\n            \r\n\r\n            \r\n
+        \           \r\n                <li>\r\n                    <a href=\"/online-applications/applicationDetails.do?keyVal=_CARDIFF_DCAPR_126508&amp;activeTab=summary\"
+        id=\"searchresultsback\">\r\n                        Planning Application\r\n
+        \                       \r\n                        \r\n                            19/00263/DCH\r\n
+        \                       \r\n                    </a>\r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n            \r\n            \r\n\r\n\r\n
+        \           \r\n                \r\n             \r\n            \r\n\r\n
+        \           \r\n            \r\n                \r\n            \r\n            \r\n
+        \           \r\n            <li>\r\n                <a href=\"/online-applications/propertyDetails.do?activeTab=printPreview&amp;keyVal=_CARDIFF_PROPLPI_366211_2\"
+        id=\"print\" rel=\"external\">\r\n                    <img src=\"/online-applications-skin/images/button_print.gif\"
+        alt=\"Print summary icon\" width=\"53\" height=\"22\" border=\"0\"/>\r\n                </a>\r\n
+        \           </li>\r\n            \r\n\r\n            \r\n        </ul>\r\n\r\n
+        \   </div>\r\n\r\n\r\n     \r\n\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabs\" -->\r\n    \r\n    <ul class=\"tabs\">\r\n\r\n        \r\n\r\n
+        \           \r\n                \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/propertyDetails.do?activeTab=summary&amp;keyVal=_CARDIFF_PROPLPI_366211_2\"
+        id=\"tab_summary\" class=\"active\">\r\n                        <span>\r\n
+        \                           Address\r\n                            \r\n                        </span>\r\n
+        \                   </a>\r\n\r\n                    \r\n                    \r\n
+        \                   \r\n                        \r\n                        \r\n
+        \                   \r\n                </li>\r\n            \r\n\r\n            \r\n\r\n
+        \       \r\n\r\n            \r\n                \r\n                <li>\r\n\r\n
+        \                    \r\n                    <a href=\"/online-applications/propertyDetails.do?activeTab=relatedCases&amp;keyVal=_CARDIFF_PROPLPI_366211_2\"
+        id=\"tab_relatedCases\">\r\n                        <span>\r\n                            Property
+        History\r\n                            \r\n                                \r\n
+        \                               (2)\r\n                            \r\n                        </span>\r\n
+        \                   </a>\r\n\r\n                    \r\n                    \r\n
+        \                   \r\n                </li>\r\n            \r\n\r\n            \r\n\r\n
+        \       \r\n\r\n            \r\n                \r\n                <li>\r\n\r\n
+        \                    \r\n                    <a href=\"/online-applications/propertyDetails.do?activeTab=constraints&amp;keyVal=_CARDIFF_PROPLPI_366211_2\"
+        id=\"tab_constraints\">\r\n                        <span>\r\n                            Constraints\r\n
+        \                           \r\n                                \r\n                                (1)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n\r\n
+        \           \r\n\r\n        \r\n    </ul>\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabsubnav\" --><!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"pagebody\" -->\n    \r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\n
+        \   \n        \n        \n    \n\n    \n    \n    \n    \n    \n        \n
+        \       \n    \n\n    <div class=\"tabcontainer toplevel\">\n\n        \n
+        \       \n        \n            \n            <table id=\"propertyAddress\"
+        summary=\"Property address\">\r\n<tr class=\"row0\">\r\n<th scope=\"row\">UPRN:</th>\r\n<td>10023549353</td>\r\n</tr>\r\n<tr
+        class=\"row1\">\r\n<th scope=\"row\">Full Address:</th>\r\n<td>MILL FARM HOUSE,
+        MILL FARM, ST MELLONS ROAD, LISVANE, CARDIFF, CF14 0SH</td>\r\n</tr>\r\n<tr
+        class=\"row0\">\r\n<th scope=\"row\">Property Description:</th>\r\n<td>MILL
+        FARM</td>\r\n</tr>\r\n<tr class=\"row1\">\r\n<th scope=\"row\">Property Number:</th>\r\n<td/>\r\n</tr>\r\n<tr
+        class=\"row0\">\r\n<th scope=\"row\">Street:</th>\r\n<td>ST MELLONS ROAD</td>\r\n</tr>\r\n<tr
+        class=\"row1\">\r\n<th scope=\"row\">Town:</th>\r\n<td>CARDIFF</td>\r\n</tr>\r\n<tr
+        class=\"row0\">\r\n<th scope=\"row\">Postcode:</th>\r\n<td>CF14 0SH</td>\r\n</tr>\r\n<tr
+        class=\"row1\">\r\n<th scope=\"row\">Ward:</th>\r\n<td/>\r\n</tr>\r\n<tr class=\"row0\">\r\n<th
+        scope=\"row\">Parish:</th>\r\n<td/>\r\n</tr>\r\n</table>\r\n\n        \n\n
+        \       \n        \n\n        \n        \n            \n        \n\n    </div>\n<!--
+        #EndEditable -->\r\n                    <!-- #BeginEditable \"pagefoot\" --><!--
+        #EndEditable -->\r\n                </div>\r\n                <!-- END WAM
+        CONTENT -->\r\n                \r\n                <p id=\"poweredBy\"><a
+        href=\"http://www.idoxgroup.com/\" target=\"_blank\" title=\"This link will
+        open a new window\"><img src=\"/online-applications-skin/images/idox.gif\"
+        alt=\"an Idox solution\" /></a></p>\r\n            </div>\r\n\t\t\t<div id=\"footer\">\r\n\t\t\t\t<div
+        class=\"container\">\t\t\t\t\t\r\n\t\t\t\t\t<div id=\"links\">\r\n\t\t\t\t\t\t<ul>\r\n\t\t\t\t\t\t\t<li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/Site_Map/Pages/default.aspx\">Site
+        map</a></li><li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Cookies/Pages/Cookies.aspx\">Cookies</a></li><li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/New_Disclaimer/Pages/default.aspx\">Disclaimer</a></li>\r\n\t\t\t\t\t\t</ul>\r\n\t\t\t\t\t</div>\r\n\t\t\t\t\t<div
+        class=\"clear\"></div>\r\n\t\t\t\t</div>\r\n\t\t\t</div>\r\n\t\t\t<div id=\"footerBottom\">\r\n\t\t\t
+        \   <div class=\"container\">\r\n\t\t\t        <div id=\"footercontent\"><p>&copy;
+        <script type=\"text/javascript\">document.write(new Date().getFullYear());</script>
+        Cardiff Council</p></div>\r\n\t\t\t        <div class=\"clear\"></div>\r\n\t\t\t
+        \   </div>\r\n\t\t\t</div>\r\n        </div>\r\n    </div>\r\n    <!-- IDOX
+        PA END -->\r\n\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Mon, 15 Apr 2019 11:15:08 GMT
+- request:
+    method: get
+    uri: https://planningonline.cardiff.gov.uk/online-applications/applicationDetails.do?activeTab=summary&keyVal=_CARDIFF_DCAPR_126502
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip,deflate,identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mechanize/2.7.6 Ruby/2.6.2p47 (http://github.com/sparklemotion/mechanize/)
+      Accept-Charset:
+      - ISO-8859-1,utf-8;q=0.7,*;q=0.7
+      Accept-Language:
+      - en-us,en;q=0.5
+      Cookie:
+      - JSESSIONID=ss9pKoHL32yHmhJQONSykek96zXCSSZ75skxJ5v1.vmidoxweblve; WSLang-CFC001=EN
+      Host:
+      - planningonline.cardiff.gov.uk
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '300'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - text/html; charset=UTF-8
+      Expires:
+      - Mon, 15 Apr 2019 11:15:52 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ua-Compatible:
+      - IE=edge
+      Server:
+      - Apache
+      Set-Cookie:
+      - WSLang-CFC001=EN; expires=Mon, 15-Apr-2069 11:15:49 GMT; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 15 Apr 2019 11:15:52 GMT
+      Content-Length:
+      - '28453'
+    body:
+      encoding: UTF-8
+      string: "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n    \n\n    \n\n<!DOCTYPE html PUBLIC
+        \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\r\n<html
+        lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\r\n<head>\r\n\t\r\n\t<!--
+        #BeginEditable \"doctitle\" -->\r\n    <title>\r\n    19/00257/MNR\r\n    |\r\n
+        \   \r\n        NEW BUILD EXTENSION TO EXISTING POOL HALL TO CREATE SMALL
+        RELAX AREA\r\n        \r\n        |\r\n        \r\n    \r\n\r\n    \r\n\r\n
+        \   \r\n\r\n    \r\n    \r\n    \r\n    \r\n    \r\n        \r\n        BANNATYNE
+        HEALTH CLUB, PARC TY GLAS, LLANISHEN, CARDIFF, CF14 5DU\r\n    \r\n    \r\n
+        \   </title>\r\n<!-- #EndEditable -->\r\n    <!-- #BeginEditable \"metatags\"
+        --><!-- #EndEditable -->\r\n\t\r\n    <meta http-equiv=\"Content-Type\" content=\"text/html;
+        charset=UTF-8\" />\r\n\t\r\n\t<!-- Customer metatags -->\r\n\t\r\n\t\r\n\t<!--
+        Favicon link -->\r\n    <link rel=\"icon\" href=\"/online-applications-skin/images/cardiff/favicon.ico\"
+        type=\"image/x-icon\" />\r\n\t\r\n    <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/screen.css\"
+        type=\"text/css\" media=\"screen,projection\" />\r\n    <link rel=\"stylesheet\"
+        href=\"/online-applications-skin/styles/theme1.css\" type=\"text/css\"/>    \r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/print.css\"
+        type=\"text/css\" media=\"print\" />\r\n\t\r\n    <script type=\"text/javascript\"
+        src=\"/online-applications-skin/scripts/jquery.min.js\"></script>\r\n    <script
+        type=\"text/javascript\" src=\"/online-applications-skin/scripts/jquery.toolbar.idox.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/common.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/checkbox.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/amplify.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/createCommentCookie.js\"></script>\r\n
+        \       \r\n\t<!-- Customer Analytics Script -->\r\n\t\r\n\t\r\n    <script
+        type=\"text/javascript\">\r\n    \t$('html').addClass('js');\r\n    \t$(document).ready(function(){\r\n
+        \   \t\t$('.main#apply>span:first-child').attr('tabindex', '0')\r\n    \t});\r\n
+        \   </script>\r\n    \r\n    <!-- #BeginEditable \"mobile\" --><!-- #EndEditable
+        -->\r\n    <!-- #BeginEditable \"head\" -->\r\n\t<script type=\"text/javascript\">\r\n\t
+        \   jQuery(document).ready(function() {\t\r\n\t\t\tjQuery('#pa').before('<img
+        src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\" id=\"preload\"
+        />');\r\n\t\t\tjQuery('#preload').hide();\r\n\t\t\tjQuery('.tabs a#tab_documents').click(
+        function(event) {\r\n\t\t\t\t  window.clearTimeout(window.timeOutId);\r\n\t\t\t\t
+        \ window.timeOutId = window.setTimeout(function() {\r\n\t\t\t\t\t\tjQuery('.content').before('<div
+        id=\"overlay\"></div><div id=\"loading\"><div id=\"message\">Loading. Please
+        wait.... <img src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\"
+        height=\"19\" width=\"220\" style=\"background:#fff;\" /></div></div>');\r\n\t\t\t\t
+        \ },10);\r\n\t\t\t\t});\r\n\t\t\tjQuery('p.associateddocument a').click( function(event)
+        {\r\n\t\t\t\t  window.clearTimeout(window.timeOutId);\r\n\t\t\t\t  window.timeOutId
+        = window.setTimeout(function() {\r\n\t\t\t\t\t\tjQuery('.content').before('<div
+        id=\"overlay\"></div><div id=\"loading\"><div id=\"message\">Loading. Please
+        wait.... <img src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\"
+        height=\"19\" width=\"220\" style=\"background:#fff;\" /></div></div>');\r\n\t\t\t\t
+        \ },10);\r\n\t\t\t\t});\r\n\r\n\t\t});\r\n    </script>\r\n    \r\n    <link
+        rel=\"stylesheet\" href=\"/online-applications-skin/styles/simple_social_share.min.css\"
+        type=\"text/css\"/>\r\n    <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/simple_social_share.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\">\r\n        $(document).ready(function(){\r\n
+        \           \r\n            \r\n            $(\"share-button\").simpleSocialShare({\r\n
+        \               sites: \"twitter,email\", \r\n                url: window.location.href,
+        \r\n                title: \"Online application\", \r\n                description:
+        \"Please look at this Planning Application: \", \r\n                shareType:
+        \"button\", \r\n                buttonSide: \"left\", \r\n                orientation:
+        \"horizontal\"\r\n            });\r\n        });\r\n\t</script>\r\n\t<!--
+        #EndEditable -->\r\n    <!-- #BeginEditable \"webapp\" --><!-- #EndEditable
+        -->\r\n\r\n</head>\r\n<body>\r\n\r\n    <a href=\"#pageheading\" class=\"sr-only\">Skip
+        to main content</a>\r\n\r\n    <!-- IDOX PA START -->\r\n    <div id=\"idox\">\r\n
+        \       <div id=\"pa\">\r\n\t\t\t<div id=\"header\"><!-- Selector: Selector
+        1 -->\r\n<style>\r\n#langStyle{float:right; margin-top: 10px; margin-right:
+        30px; background:transparent; font-size:13px; cursor:pointer; border:1px solid
+        #fff !important;border-radius:2px; z-index:999; background-color: #fff; padding:2px;}\r\n#langStyle:hover{text-decoration:
+        underline;}</style>\r\n<div>\r\n\r\n<!--CYS--><a id=\"langStyle\" href=\"/online-applications/applicationDetails.do?keyVal=_CARDIFF_DCAPR_126502&activeTab=summary&lang=CY\">Cymraeg</a><!--CYE-->\r\n</div>\r\n\t\t\t\t<div
+        class=\"container\">\r\n\t\t\t\t\t<div id=\"logo\"><a href=\"https://www.cardiff.gov.uk/\"
+        title=\"Cardiff Council home page\"><img src=\"/online-applications-skin/images/cardiff/logo.png\"
+        alt=\"Council logo\" /><span class=\"sr-only\">Cardiff Council</span></a></div>\r\n\t\t\t\t\t<div
+        id=\"headertitle\"><span></span></div>\r\n\t\t\t\t\t<div class=\"clear\"></div>\r\n\t\t\t\t</div>\t\r\n\t\t\t</div>\r\n\t\t\t<div
+        id=\"breadcrumbs\" class=\"container\">\r\n\t\t\t\t<ul>\r\n\t\t\t\t\t\r\n\t\t\t\t</ul>\r\n\t\t\t</div>\r\n
+        \           <div class=\"container\">\r\n       \t\t\t<div id=\"toolbar\"
+        class=\"nojs\">\r\n                    <ul>\t\r\n                        <li
+        id=\"search\" class=\"main\"><span tabindex=\"0\">Search&nbsp;</span><span
+        class=\"caret\"></span>\r\n   \t\t\t\t\t\t\t<ul>\t\r\n\t\t\t\t\t\t\t\t<!--
+        #BeginLibraryItem \"/Library/searchModulesNavItems.lbi\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \       \r\n            <li id=\"planLinks\">\r\n                <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\"
+        >\r\n                    <span>Planning</span>\r\n                </a>\r\n
+        \               <ul>\r\n                    <li id=\"planBasicSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\">\r\n
+        \                           Simple Search\r\n                        </a>\r\n
+        \                   </li>\r\n\r\n                    <li id=\"planAdvancedSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=advanced&amp;searchType=Application\">\r\n
+        \                           Advanced\r\n                        </a>\r\n                    </li>\r\n
+        \                   <li id=\"planListSearch\">\r\n                        <a
+        href=\"/online-applications/search.do?action=weeklyList&amp;searchType=Application\">\r\n
+        \                           Weekly/Monthly Lists\r\n                        </a>\r\n
+        \                   </li>\r\n                    <li id=\"planPropertySearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=property&amp;type=custom\">\r\n
+        \                           Property Search\r\n                        </a>\r\n
+        \                   </li>\r\n\t\t\t\t\t\r\n                    \r\n\t\t\t\t\t\r\n
+        \               </ul>\r\n            </li>\r\n        \r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        <!-- #EndLibraryItem -->\r\n                        \t</ul>\r\n\t\t\t\t\t\t</li>\r\n
+        \                       <!-- #BeginEditable \"applicationForms\" -->\n\n\n\n\n\n
+        \  \n<!-- #EndEditable -->   \t\t\t\t\r\n                        <li id=\"myprofile\"
+        class=\"main\"><span tabindex=\"0\">My Profile&nbsp;</span><span class=\"caret\"></span>\r\n
+        \                           <ul>\r\n                              <!-- #BeginLibraryItem
+        \"/Library/consulteeInTrayNavItem.lbi\" -->\n\n\n\n\n\n\n    <!-- #EndLibraryItem
+        -->\r\n                                <li><a href=\"/online-applications/registered/displayUserDetails.do\">Profile
+        Details</a></li>\r\n                                <li><a href=\"/online-applications/registered/savedSearch.do?action=display\">Saved
+        Searches</a></li>\r\n                                <li><a href=\"/online-applications/registered/userAdmin.do?action=showNotifiedApplications\">Notified
+        Applications</a></li>\r\n                                <li><a href=\"/online-applications/registered/trackedApplication.do?action=display\">Tracked
+        Applications</a></li>\r\n                                <!-- #BeginEditable
+        \"formSubmissions\" -->\n\n\n\n\n\n\n\n\n<!-- #EndEditable -->    \t\r\n                            </ul>\r\n
+        \                       </li>\r\n                        <li id=\"loginLink\"
+        class=\"main\"><!-- #BeginEditable \"loginlogout\" -->\n\n\n\n\n\n\n\n\n\n\n\t<a
+        href=\"/online-applications/registered/userAdmin.do\">Login</a>\n<!-- #EndEditable
+        --></li>\r\n                        <!-- #BeginEditable \"register\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \  \r\n\r\n\r\n\t<li id=\"register\">\r\n        <a href=\"/online-applications/registrationWizard.do?action=start\">Register</a>\r\n\t</li>\r\n\r\n<!--
+        #EndEditable -->\r\n                        <!-- #BeginLibraryItem \"/Library/applyOnlineNavItems.lbi\"
+        -->\r\n\r\n\r\n\r\n\r\n\r\n<!-- #EndLibraryItem -->\r\n                    </ul>\r\n
+        \   \t\t\t</div>\r\n\r\n    \t\t\t<!-- #BeginEditable \"headlinenews\" --><!--
+        #EndEditable -->\r\n                 \r\n                <div id=\"pageheading\">\r\n
+        \                   <h1><strong>Planning</strong>&nbsp;&ndash;&nbsp;<!-- #BeginEditable
+        \"pageheading\" -->Application Summary<!-- #EndEditable --></h1>\r\n                    <!--
+        #BeginEditable \"helplink\" -->\r\n<p class=\"pagehelp\">\r\n\t<a title=\"Help
+        with this page (opens in a new window)\" rel=\"external\" target=\"_blank\"
+        href=\"/online-applications/help/pagehelp/applications.htm\">\r\n\t\tHelp
+        with this page\r\n\t<span> (opens in a new window)</span>\r\n\t</a>\r\n</p>\r\n<!--
+        #EndEditable -->\r\n                </div>\r\n                \r\n                <!--
+        START WAM CONTENT -->\r\n                <div class=\"content\">\r\n                    <!--
+        #BeginEditable \"errormsg\" -->\n        \n        \n\n        \n        \n
+        \   <!-- #EndEditable -->\r\n                    <!-- #BeginEditable \"pagehead\"
+        -->\r\n\r\n    <div class=\"addressCrumb\">\r\n        <span class=\"caseNumber\">\r\n
+        \           \r\n\r\n            \r\n                19/00257/MNR\r\n            \r\n
+        \       </span>\r\n\r\n        <span class=\"divider1\">|</span>\r\n\r\n        \r\n
+        \           <span class=\"description\">\r\n                NEW BUILD EXTENSION
+        TO EXISTING POOL HALL TO CREATE SMALL RELAX AREA\r\n            </span>\r\n
+        \           \r\n                <span class=\"divider2\">|</span>\r\n            \r\n
+        \       \r\n\r\n        \r\n\r\n        \r\n\r\n        \r\n        \r\n        \r\n
+        \       \r\n        \r\n            \r\n            <span class=\"address\">\r\n
+        \               BANNATYNE HEALTH CLUB, PARC TY GLAS, LLANISHEN, CARDIFF, CF14
+        5DU\r\n            </span>\r\n        \r\n        \r\n    </div>\r\n\r\n\r\n
+        \   <div id=\"applicationTools\">\r\n        <ul>\r\n            \r\n            \r\n
+        \               \r\n                    \r\n                        \r\n                            \r\n
+        \                           \r\n                                \r\n                                    <li>\r\n
+        \                                       <a href=\"/online-applications/searchResultsBack.do?action=back\"
+        id=\"searchresultsback\">Back to search results</a>\r\n                                    </li>\r\n
+        \                               \r\n                            \r\n                        \r\n
+        \                   \r\n                    \r\n                    \r\n                \r\n
+        \           \r\n\r\n            \r\n\r\n            \r\n            \r\n\r\n
+        \           \r\n\r\n            \r\n            \r\n                \r\n                    <li>\r\n
+        \                       <form name=\"trackForm\" method=\"post\" action=\"/online-applications/registered/trackedApplicationSubmit.do?action=track\"><input
+        type=\"hidden\" name=\"org.apache.struts.taglib.html.TOKEN\" value=\"ffc997f761936dbb2ea0018e2e10c906\"
+        />\r\n                            <input type=\"hidden\" name=\"caseNo\" value=\"19/00257/MNR\"
+        />\r\n                            <input type=\"hidden\" name=\"caseType\"
+        value=\"Application\" />\r\n                            <input type=\"hidden\"
+        name=\"address\" value=\"BANNATYNE HEALTH CLUB, PARC TY GLAS, LLANISHEN, CARDIFF,
+        CF14 5DU\" />\r\n                            <input type=\"hidden\" name=\"description\"
+        value=\"NEW BUILD EXTENSION TO EXISTING POOL HALL TO CREATE SMALL RELAX AREA\"
+        />\r\n                            <input type=\"hidden\" name=\"status\" value=\"Decided\"
+        />\r\n                            <input type=\"hidden\" name=\"trackingStatus\"
+        value=\"Decided\" />\r\n                            <input type=\"hidden\"
+        name=\"caseTechnicalKey\" value=\"_CARDIFF_DCAPR_126502\" />\r\n                            <input
+        class=\"casefiletrack\"\r\n                                   src=\"/online-applications-skin/images/button_track.gif\"\r\n
+        \                                  type=\"image\"\r\n                                   name=\"submit\"\r\n
+        \                                  altKey=\"casedetails.track\"\r\n                                   title=\"Get
+        informed when this item is updated\"/>\r\n                        </form>\r\n
+        \                   </li>\r\n                \r\n\r\n                \r\n
+        \           \r\n\r\n\r\n            \r\n                \r\n             \r\n
+        \           \r\n\r\n            \r\n            \r\n                \r\n            \r\n
+        \           \r\n            \r\n            <li>\r\n                <a href=\"/online-applications/applicationDetails.do?activeTab=printPreview&amp;keyVal=_CARDIFF_DCAPR_126502\"
+        id=\"print\" rel=\"external\">\r\n                    <img src=\"/online-applications-skin/images/button_print.gif\"
+        alt=\"Print summary icon\" width=\"53\" height=\"22\" border=\"0\"/>\r\n                </a>\r\n
+        \           </li>\r\n            \r\n\r\n            \r\n        </ul>\r\n\r\n
+        \   </div>\r\n\r\n\r\n     \r\n\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabs\" -->\r\n    \r\n    <ul class=\"tabs\">\r\n\r\n        \r\n\r\n
+        \           \r\n                \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/applicationDetails.do?activeTab=summary&amp;keyVal=_CARDIFF_DCAPR_126502\"
+        id=\"tab_summary\" class=\"active\">\r\n                        <span>\r\n
+        \                           Details\r\n                            \r\n                        </span>\r\n
+        \                   </a>\r\n\r\n                    \r\n                    \r\n
+        \                   \r\n                        \r\n                        \r\n\r\n
+        \                           <ul class=\"subtabs\">\r\n                                \r\n
+        \                                   \r\n                                        <li>\r\n
+        \                                           \r\n                                            <a
+        href=\"/online-applications/applicationDetails.do?activeTab=summary&amp;keyVal=_CARDIFF_DCAPR_126502\"
+        id=\"subtab_summary\" class=\"active\">\r\n                                                <span>\r\n
+        \                                                   Summary\r\n                                                    \r\n
+        \                                               </span>\r\n                                            </a>\r\n
+        \                                       </li>\r\n                                    \r\n
+        \                               \r\n                                    \r\n
+        \                                       <li>\r\n                                            \r\n
+        \                                           <a href=\"/online-applications/applicationDetails.do?activeTab=details&amp;keyVal=_CARDIFF_DCAPR_126502\"
+        id=\"subtab_details\">\r\n                                                <span>\r\n
+        \                                                   Further Information\r\n
+        \                                                   \r\n                                                </span>\r\n
+        \                                           </a>\r\n                                        </li>\r\n
+        \                                   \r\n                                \r\n
+        \                                   \r\n                                        <li>\r\n
+        \                                           \r\n                                            <a
+        href=\"/online-applications/applicationDetails.do?activeTab=contacts&amp;keyVal=_CARDIFF_DCAPR_126502\"
+        id=\"subtab_contacts\">\r\n                                                <span>\r\n
+        \                                                   Contacts\r\n                                                    \r\n
+        \                                               </span>\r\n                                            </a>\r\n
+        \                                       </li>\r\n                                    \r\n
+        \                               \r\n                                    \r\n
+        \                                       <li>\r\n                                            \r\n
+        \                                           <a href=\"/online-applications/applicationDetails.do?activeTab=dates&amp;keyVal=_CARDIFF_DCAPR_126502\"
+        id=\"subtab_dates\">\r\n                                                <span>\r\n
+        \                                                   Important Dates\r\n                                                    \r\n
+        \                                               </span>\r\n                                            </a>\r\n
+        \                                       </li>\r\n                                    \r\n
+        \                               \r\n                            </ul>\r\n\r\n
+        \                       \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n                \r\n
+        \               <li>\r\n\r\n                     \r\n                    <a
+        href=\"/online-applications/applicationDetails.do?activeTab=makeComment&amp;keyVal=_CARDIFF_DCAPR_126502\"
+        id=\"tab_makeComment\">\r\n                        <span>\r\n                            Comments\r\n
+        \                           \r\n                                \r\n                                (0)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n\r\n
+        \           \r\n                <li class=\"nodocuments\">\r\n                    <span>\r\n
+        \                       Constraints\r\n                        \r\n                            \r\n
+        \                           (0)\r\n                        \r\n                    </span>\r\n
+        \               </li>\r\n            \r\n\r\n        \r\n\r\n            \r\n
+        \               \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/applicationDetails.do?activeTab=documents&amp;keyVal=_CARDIFF_DCAPR_126502\"
+        id=\"tab_documents\">\r\n                        <span>\r\n                            Documents\r\n
+        \                           \r\n                                \r\n                                (18)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n                \r\n
+        \               <li>\r\n\r\n                     \r\n                    <a
+        href=\"/online-applications/applicationDetails.do?activeTab=relatedCases&amp;keyVal=_CARDIFF_DCAPR_126502\"
+        id=\"tab_relatedCases\">\r\n                        <span>\r\n                            Related
+        Cases\r\n                            \r\n                                \r\n
+        \                               (1)\r\n                            \r\n                        </span>\r\n
+        \                   </a>\r\n\r\n                    \r\n                    \r\n
+        \                   \r\n                </li>\r\n            \r\n\r\n            \r\n\r\n
+        \       \r\n\r\n            \r\n\r\n            \r\n\r\n        \r\n    </ul>\r\n<!--
+        #EndEditable -->\r\n                    <!-- #BeginEditable \"tabsubnav\"
+        --><!-- #EndEditable -->\r\n                    <!-- #BeginEditable \"pagebody\"
+        -->\n    \r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\n
+        \   \n        \n        \n    \n\n    \n    \n    \n    \n    \n\n    <div
+        class=\"tabcontainer\">\n\n        \n        \n        \n\n        \n        \n\n
+        \           \n            \n                \n            \n\n            \n
+        \               <table id=\"simpleDetailsTable\" summary=\"Case Details\">\n\n
+        \                   \n                    \n                        \n                            <tr>\n
+        \                               <th scope=\"row\" width=\"40%\">\n                                    Reference\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            19/00257/MNR\n
+        \                                       \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Alternative Reference\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            PP-07613169\n
+        \                                       \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Application Received\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            Fri
+        08 Feb 2019\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Application Validated\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            Fri
+        08 Feb 2019\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Address\n                                </th>\n
+        \                               <td>\n                                    \n
+        \                                       \n                                        \n
+        \                                           BANNATYNE HEALTH CLUB, PARC TY
+        GLAS, LLANISHEN, CARDIFF, CF14 5DU\n                                        \n
+        \                                   \n                                </td>\n
+        \                           </tr>\n                        \n                    \n
+        \                       \n                            <tr>\n                                <th
+        scope=\"row\" width=\"40%\">\n                                    Proposal\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            NEW
+        BUILD EXTENSION TO EXISTING POOL HALL TO CREATE SMALL RELAX AREA\n                                        \n
+        \                                   \n                                </td>\n
+        \                           </tr>\n                        \n                    \n
+        \                       \n                            <tr>\n                                <th
+        scope=\"row\" width=\"40%\">\n                                    Status\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                           <span class=\"caseDetailsStatus\">Decided</span>\n
+        \                                       \n                                        \n
+        \                                   \n                                </td>\n
+        \                           </tr>\n                        \n                    \n
+        \                       \n                            <tr>\n                                <th
+        scope=\"row\" width=\"40%\">\n                                    Decision\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            Permission
+        be granted\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Decision Issued Date\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            Mon
+        08 Apr 2019\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Appeal Decision\n                                </th>\n
+        \                               <td>\n                                    \n
+        \                                       \n                                        \n
+        \                                           \n                                        \n
+        \                                   \n                                </td>\n
+        \                           </tr>\n                        \n                    \n\n
+        \               </table>\n\n                \n                \n\n                \n\n
+        \           \n\n            \n\n        \n\n        \n        \n            \n
+        \               <div id=\"summaryInfo\">\n                    \n                    \n
+        \                   \n                        \n                            \n
+        \                       \n                    \n\n                    \n                    \n
+        \                       <p class=\"associateddocument\">There are <a href=\"/online-applications/applicationDetails.do?activeTab=documents&amp;keyVal=_CARDIFF_DCAPR_126502\">18
+        documents</a> associated with this application.</p><p class=\"associatedcase\">There
+        are 0 cases associated with this application.</p><p class=\"associatedproperty\">There
+        is <a href=\"/online-applications/applicationDetails.do?activeTab=relatedCases&amp;keyVal=_CARDIFF_DCAPR_126502\">1
+        property</a> associated with this application.</p>\r\n\n                    \n
+        \               </div>\n            \n        \n\n    </div>\n<!-- #EndEditable
+        -->\r\n                    <!-- #BeginEditable \"pagefoot\" --><!-- #EndEditable
+        -->\r\n                </div>\r\n                <!-- END WAM CONTENT -->\r\n
+        \               \r\n                <p id=\"poweredBy\"><a href=\"http://www.idoxgroup.com/\"
+        target=\"_blank\" title=\"This link will open a new window\"><img src=\"/online-applications-skin/images/idox.gif\"
+        alt=\"an Idox solution\" /></a></p>\r\n            </div>\t\r\n\t\t\t<div
+        id=\"footer\">\r\n\t\t\t\t<div class=\"container\">\t\t\t\t\t\r\n\t\t\t\t\t<div
+        id=\"links\">\r\n\t\t\t\t\t\t<ul>\r\n\t\t\t\t\t\t\t<li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Site_Map/Pages/default.aspx\">Site
+        map</a></li><li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Cookies/Pages/Cookies.aspx\">Cookies</a></li><li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/New_Disclaimer/Pages/default.aspx\">Disclaimer</a></li>\r\n\t\t\t\t\t\t</ul>\r\n\t\t\t\t\t</div>\r\n\t\t\t\t\t<div
+        class=\"clear\"></div>\r\n\t\t\t\t</div>\r\n\t\t\t</div>\r\n\t\t\t<div id=\"footerBottom\">\r\n\t\t\t
+        \   <div class=\"container\">\r\n\t\t\t        <div id=\"footercontent\"><p>&copy;
+        <script type=\"text/javascript\">document.write(new Date().getFullYear());</script>
+        Cardiff Council</p></div>\r\n\t\t\t        <div class=\"clear\"></div>\r\n\t\t\t
+        \   </div>\r\n\t\t\t</div>\r\n        </div>    \r\n    </div>  \r\n    <!--
+        IDOX PA END -->           \r\n\t\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Mon, 15 Apr 2019 11:15:21 GMT
+- request:
+    method: get
+    uri: https://planningonline.cardiff.gov.uk/online-applications/applicationDetails.do?activeTab=relatedCases&keyVal=_CARDIFF_DCAPR_126502
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip,deflate,identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mechanize/2.7.6 Ruby/2.6.2p47 (http://github.com/sparklemotion/mechanize/)
+      Accept-Charset:
+      - ISO-8859-1,utf-8;q=0.7,*;q=0.7
+      Accept-Language:
+      - en-us,en;q=0.5
+      Cookie:
+      - JSESSIONID=ss9pKoHL32yHmhJQONSykek96zXCSSZ75skxJ5v1.vmidoxweblve; WSLang-CFC001=EN
+      Host:
+      - planningonline.cardiff.gov.uk
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '300'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - text/html; charset=UTF-8
+      Expires:
+      - Mon, 15 Apr 2019 11:15:54 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ua-Compatible:
+      - IE=edge
+      Server:
+      - Apache
+      Set-Cookie:
+      - WSLang-CFC001=EN; expires=Mon, 15-Apr-2069 11:15:53 GMT; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 15 Apr 2019 11:15:54 GMT
+      Content-Length:
+      - '20044'
+    body:
+      encoding: UTF-8
+      string: "\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n<!DOCTYPE
+        html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\r\n<html
+        lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\r\n<head>\r\n\t\r\n\t<!--
+        #BeginEditable \"doctitle\" -->\r\n    <title>\r\n    19/00257/MNR\r\n    |\r\n
+        \   \r\n        NEW BUILD EXTENSION TO EXISTING POOL HALL TO CREATE SMALL
+        RELAX AREA\r\n        \r\n        |\r\n        \r\n    \r\n\r\n    \r\n\r\n
+        \   \r\n\r\n    \r\n    \r\n    \r\n    \r\n    \r\n        \r\n        BANNATYNE
+        HEALTH CLUB, PARC TY GLAS, LLANISHEN, CARDIFF, CF14 5DU\r\n    \r\n    \r\n
+        \   </title>\r\n<!-- #EndEditable -->\r\n    <!-- #BeginEditable \"metatags\"
+        --><!-- #EndEditable -->\r\n\t\r\n    <meta http-equiv=\"Content-Type\" content=\"text/html;
+        charset=UTF-8\" />\r\n\t\r\n\t<!-- Customer metatags -->\r\n\t\r\n\t\r\n\t<!--
+        Favicon link -->\r\n    <link rel=\"icon\" href=\"/online-applications-skin/images/cardiff/favicon.ico\"
+        type=\"image/x-icon\" />\r\n\t\r\n    <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/screen.css\"
+        type=\"text/css\" media=\"screen,projection\" />\r\n    <link rel=\"stylesheet\"
+        href=\"/online-applications-skin/styles/theme1.css\" type=\"text/css\"/>    \r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/print.css\"
+        type=\"text/css\" media=\"print\" />\r\n\t\r\n    <script type=\"text/javascript\"
+        src=\"/online-applications-skin/scripts/jquery.min.js\"></script>\r\n    <script
+        type=\"text/javascript\" src=\"/online-applications-skin/scripts/jquery.toolbar.idox.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/common.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/checkbox.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/amplify.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/createCommentCookie.js\"></script>\r\n
+        \       \r\n\t<!-- Customer Analytics Script -->\r\n\t\r\n\t\r\n    <script
+        type=\"text/javascript\">\r\n    \t$('html').addClass('js');\r\n    \t$(document).ready(function(){\r\n
+        \   \t\t$('.main#apply>span:first-child').attr('tabindex', '0')\r\n    \t});\r\n
+        \   </script>\r\n    \r\n    <!-- #BeginEditable \"mobile\" --><!-- #EndEditable
+        -->\r\n    <!-- #BeginEditable \"head\" --><!-- #EndEditable -->\r\n    <!--
+        #BeginEditable \"webapp\" -->\r\n\t<script type=\"text/javascript\">\r\n\t
+        \   jQuery(document).ready(function() {\t\t\r\n\t\t\tjQuery('#pa').before('<img
+        src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\" id=\"preload\"
+        />');\r\n\t\t\tjQuery('#preload').hide();\r\n\t\t\tjQuery('.tabs a#tab_documents').click(
+        function(event) {\r\n\t\t\t\t  window.clearTimeout(window.timeOutId);\r\n\t\t\t\t
+        \ window.timeOutId = window.setTimeout(function() {\r\n\t\t\t\t\t\tjQuery('.content').before('<div
+        id=\"overlay\"></div><div id=\"loading\"><div id=\"message\">Loading. Please
+        wait.... <img src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\"
+        height=\"19\" width=\"220\" style=\"background:#fff;\" /></div></div>');\r\n\t\t\t\t
+        \ },10); \r\n\t\t\t\t});\r\n\t\t\t\t\r\n\t\t});\r\n\t</script>\r\n            \r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/simple_social_share.min.css\"
+        type=\"text/css\"/>\r\n    <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/simple_social_share.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\">\r\n        $(document).ready(function(){\r\n
+        \           \r\n            \r\n            $(\"share-button\").simpleSocialShare({\r\n
+        \               sites: \"twitter,email\", \r\n                url: window.location.href,
+        \r\n                title: \"Online application\", \r\n                description:
+        \"Please look at this Planning Application: \", \r\n                shareType:
+        \"button\", \r\n                buttonSide: \"left\", \r\n                orientation:
+        \"horizontal\"\r\n            });\r\n        });\r\n\t</script>\r\n\t<!--
+        #EndEditable -->\r\n\r\n</head>\r\n<body>\r\n\r\n    <a href=\"#pageheading\"
+        class=\"sr-only\">Skip to main content</a>\r\n\r\n    <!-- IDOX PA START -->\r\n
+        \   <div id=\"idox\">\r\n        <div id=\"pa\">\r\n\t\t\t<div id=\"header\"><!--
+        Selector: Selector 1 -->\r\n<style>\r\n#langStyle{float:right; margin-top:
+        10px; margin-right: 30px; background:transparent; font-size:13px; cursor:pointer;
+        border:1px solid #fff !important;border-radius:2px; z-index:999; background-color:
+        #fff; padding:2px;}\r\n#langStyle:hover{text-decoration: underline;}</style>\r\n<div>\r\n\r\n<!--CYS--><a
+        id=\"langStyle\" href=\"/online-applications/applicationDetails.do?activeTab=relatedCases&keyVal=_CARDIFF_DCAPR_126502&lang=CY\">Cymraeg</a><!--CYE-->\r\n</div>\r\n\t\t\t\t<div
+        class=\"container\">\r\n\t\t\t\t\t<div id=\"logo\"><a href=\"https://www.cardiff.gov.uk/\"
+        title=\"Cardiff Council home page\"><img src=\"/online-applications-skin/images/cardiff/logo.png\"
+        alt=\"Council logo\" /><span class=\"sr-only\">Cardiff Council</span></a></div>\r\n\t\t\t\t\t<div
+        id=\"headertitle\"><span></span></div>\r\n\t\t\t\t\t<div class=\"clear\"></div>\r\n\t\t\t\t</div>\t\r\n\t\t\t</div>\r\n\t\t\t<div
+        id=\"breadcrumbs\" class=\"container\">\r\n\t\t\t\t<ul>\r\n\t\t\t\t\t\r\n\t\t\t\t</ul>\r\n\t\t\t</div>\r\n
+        \           <div class=\"container\">\r\n       \t\t\t<div id=\"toolbar\"
+        class=\"nojs\">\r\n                    <ul>\t\r\n                        <li
+        id=\"search\" class=\"main\"><span tabindex=\"0\">Search&nbsp;</span><span
+        class=\"caret\"></span>\r\n   \t\t\t\t\t\t\t<ul>\t\r\n\t\t\t\t\t\t\t\t<!--
+        #BeginLibraryItem \"/Library/searchModulesNavItems.lbi\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \       \r\n            <li id=\"planLinks\">\r\n                <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\"
+        >\r\n                    <span>Planning</span>\r\n                </a>\r\n
+        \               <ul>\r\n                    <li id=\"planBasicSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\">\r\n
+        \                           Simple Search\r\n                        </a>\r\n
+        \                   </li>\r\n\r\n                    <li id=\"planAdvancedSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=advanced&amp;searchType=Application\">\r\n
+        \                           Advanced\r\n                        </a>\r\n                    </li>\r\n
+        \                   <li id=\"planListSearch\">\r\n                        <a
+        href=\"/online-applications/search.do?action=weeklyList&amp;searchType=Application\">\r\n
+        \                           Weekly/Monthly Lists\r\n                        </a>\r\n
+        \                   </li>\r\n                    <li id=\"planPropertySearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=property&amp;type=custom\">\r\n
+        \                           Property Search\r\n                        </a>\r\n
+        \                   </li>\r\n\t\t\t\t\t\r\n                    \r\n\t\t\t\t\t\r\n
+        \               </ul>\r\n            </li>\r\n        \r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        <!-- #EndLibraryItem -->\r\n                        \t</ul>\r\n\t\t\t\t\t\t</li>\r\n
+        \                       <!-- #BeginEditable \"applicationForms\" -->\n\n\n\n\n\n
+        \  \n<!-- #EndEditable -->   \t\t\t\t\r\n                        <li id=\"myprofile\"
+        class=\"main\"><span tabindex=\"0\">My Profile&nbsp;</span><span class=\"caret\"></span>\r\n
+        \                           <ul>\r\n                              <!-- #BeginLibraryItem
+        \"/Library/consulteeInTrayNavItem.lbi\" -->\n\n\n\n\n\n\n    <!-- #EndLibraryItem
+        -->\r\n                                <li><a href=\"/online-applications/registered/displayUserDetails.do\">Profile
+        Details</a></li>\r\n                                <li><a href=\"/online-applications/registered/savedSearch.do?action=display\">Saved
+        Searches</a></li>\r\n                                <li><a href=\"/online-applications/registered/userAdmin.do?action=showNotifiedApplications\">Notified
+        Applications</a></li>\r\n                                <li><a href=\"/online-applications/registered/trackedApplication.do?action=display\">Tracked
+        Applications</a></li>\r\n                                <!-- #BeginEditable
+        \"formSubmissions\" -->\n\n\n\n\n\n\n\n\n<!-- #EndEditable -->    \t\r\n                            </ul>\r\n
+        \                       </li>\r\n                        <li id=\"loginLink\"
+        class=\"main\"><!-- #BeginEditable \"loginlogout\" -->\n\n\n\n\n\n\n\n\n\n\n\t<a
+        href=\"/online-applications/registered/userAdmin.do\">Login</a>\n<!-- #EndEditable
+        --></li>\r\n                        <!-- #BeginEditable \"register\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \  \r\n\r\n\r\n\t<li id=\"register\">\r\n        <a href=\"/online-applications/registrationWizard.do?action=start\">Register</a>\r\n\t</li>\r\n\r\n<!--
+        #EndEditable -->\r\n                        <!-- #BeginLibraryItem \"/Library/applyOnlineNavItems.lbi\"
+        -->\r\n\r\n\r\n\r\n\r\n\r\n<!-- #EndLibraryItem -->\r\n                    </ul>\r\n
+        \   \t\t\t</div>\r\n\r\n    \t\t\t<!-- #BeginEditable \"headlinenews\" --><!--
+        #EndEditable -->\r\n                 \r\n                <div id=\"pageheading\">\r\n
+        \                   <h1><strong>Planning</strong>&nbsp;&ndash;&nbsp;<!-- #BeginEditable
+        \"pageheading\" -->Application Related Items<!-- #EndEditable --></h1>\r\n
+        \                   <!-- #BeginEditable \"helplink\" -->\r\n<p class=\"pagehelp\">\r\n\t<a
+        title=\"Help with this page (opens in a new window)\" rel=\"external\" target=\"_blank\"
+        href=\"/online-applications/help/pagehelp/applications.htm\">\r\n\t\tHelp
+        with this page\r\n\t<span> (opens in a new window)</span>\r\n\t</a>\r\n</p>\r\n<!--
+        #EndEditable -->\r\n                </div>\r\n                \r\n                <!--
+        START WAM CONTENT -->\r\n                <div class=\"content\">\r\n                    <!--
+        #BeginEditable \"errormsg\" --><!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"pagehead\" -->\r\n\r\n    <div class=\"addressCrumb\">\r\n
+        \       <span class=\"caseNumber\">\r\n            \r\n\r\n            \r\n
+        \               19/00257/MNR\r\n            \r\n        </span>\r\n\r\n        <span
+        class=\"divider1\">|</span>\r\n\r\n        \r\n            <span class=\"description\">\r\n
+        \               NEW BUILD EXTENSION TO EXISTING POOL HALL TO CREATE SMALL
+        RELAX AREA\r\n            </span>\r\n            \r\n                <span
+        class=\"divider2\">|</span>\r\n            \r\n        \r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        \r\n        \r\n        \r\n        \r\n        \r\n
+        \           \r\n            <span class=\"address\">\r\n                BANNATYNE
+        HEALTH CLUB, PARC TY GLAS, LLANISHEN, CARDIFF, CF14 5DU\r\n            </span>\r\n
+        \       \r\n        \r\n    </div>\r\n\r\n\r\n    <div id=\"applicationTools\">\r\n
+        \       <ul>\r\n            \r\n            \r\n                \r\n                    \r\n
+        \                       \r\n                            \r\n                            \r\n
+        \                               \r\n                                    <li>\r\n
+        \                                       <a href=\"/online-applications/searchResultsBack.do?action=back\"
+        id=\"searchresultsback\">Back to search results</a>\r\n                                    </li>\r\n
+        \                               \r\n                            \r\n                        \r\n
+        \                   \r\n                    \r\n                    \r\n                \r\n
+        \           \r\n\r\n            \r\n\r\n            \r\n            \r\n\r\n
+        \           \r\n\r\n            \r\n            \r\n                \r\n                    <li>\r\n
+        \                       <form name=\"trackForm\" method=\"post\" action=\"/online-applications/registered/trackedApplicationSubmit.do?action=track\"><input
+        type=\"hidden\" name=\"org.apache.struts.taglib.html.TOKEN\" value=\"ffc997f761936dbb2ea0018e2e10c906\"
+        />\r\n                            <input type=\"hidden\" name=\"caseNo\" value=\"19/00257/MNR\"
+        />\r\n                            <input type=\"hidden\" name=\"caseType\"
+        value=\"Application\" />\r\n                            <input type=\"hidden\"
+        name=\"address\" value=\"BANNATYNE HEALTH CLUB, PARC TY GLAS, LLANISHEN, CARDIFF,
+        CF14 5DU\" />\r\n                            <input type=\"hidden\" name=\"description\"
+        value=\"NEW BUILD EXTENSION TO EXISTING POOL HALL TO CREATE SMALL RELAX AREA\"
+        />\r\n                            <input type=\"hidden\" name=\"status\" value=\"Decided\"
+        />\r\n                            <input type=\"hidden\" name=\"trackingStatus\"
+        value=\"Decided\" />\r\n                            <input type=\"hidden\"
+        name=\"caseTechnicalKey\" value=\"_CARDIFF_DCAPR_126502\" />\r\n                            <input
+        class=\"casefiletrack\"\r\n                                   src=\"/online-applications-skin/images/button_track.gif\"\r\n
+        \                                  type=\"image\"\r\n                                   name=\"submit\"\r\n
+        \                                  altKey=\"casedetails.track\"\r\n                                   title=\"Get
+        informed when this item is updated\"/>\r\n                        </form>\r\n
+        \                   </li>\r\n                \r\n\r\n                \r\n
+        \           \r\n\r\n\r\n            \r\n                \r\n             \r\n
+        \           \r\n\r\n            \r\n            \r\n                \r\n            \r\n
+        \           \r\n            \r\n            <li>\r\n                <a href=\"/online-applications/applicationDetails.do?activeTab=printPreview&amp;keyVal=_CARDIFF_DCAPR_126502\"
+        id=\"print\" rel=\"external\">\r\n                    <img src=\"/online-applications-skin/images/button_print.gif\"
+        alt=\"Print summary icon\" width=\"53\" height=\"22\" border=\"0\"/>\r\n                </a>\r\n
+        \           </li>\r\n            \r\n\r\n            \r\n        </ul>\r\n\r\n
+        \   </div>\r\n\r\n\r\n     \r\n\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabs\" -->\r\n    \r\n    <ul class=\"tabs\">\r\n\r\n        \r\n\r\n
+        \           \r\n                \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/applicationDetails.do?activeTab=summary&amp;keyVal=_CARDIFF_DCAPR_126502\"
+        id=\"tab_summary\">\r\n                        <span>\r\n                            Details\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n                \r\n
+        \               <li>\r\n\r\n                     \r\n                    <a
+        href=\"/online-applications/applicationDetails.do?activeTab=makeComment&amp;keyVal=_CARDIFF_DCAPR_126502\"
+        id=\"tab_makeComment\">\r\n                        <span>\r\n                            Comments\r\n
+        \                           \r\n                                \r\n                                (0)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n\r\n
+        \           \r\n                <li class=\"nodocuments\">\r\n                    <span>\r\n
+        \                       Constraints\r\n                        \r\n                            \r\n
+        \                           (0)\r\n                        \r\n                    </span>\r\n
+        \               </li>\r\n            \r\n\r\n        \r\n\r\n            \r\n
+        \               \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/applicationDetails.do?activeTab=documents&amp;keyVal=_CARDIFF_DCAPR_126502\"
+        id=\"tab_documents\">\r\n                        <span>\r\n                            Documents\r\n
+        \                           \r\n                                \r\n                                (18)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n                \r\n
+        \               <li>\r\n\r\n                     \r\n                    <a
+        href=\"/online-applications/applicationDetails.do?activeTab=relatedCases&amp;keyVal=_CARDIFF_DCAPR_126502\"
+        id=\"tab_relatedCases\" class=\"active\">\r\n                        <span>\r\n
+        \                           Related Cases\r\n                            \r\n
+        \                               \r\n                                (1)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                        \r\n
+        \                       \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n\r\n
+        \           \r\n\r\n        \r\n    </ul>\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabsubnav\" --><!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"pagebody\" -->\r\n\r\n    \r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \   <div class=\"tabcontainer toplevel\">\r\n    <div id=\"relatedItems\">\r\n\r\n
+        \       \r\n            \r\n            \r\n\r\n            <!-- Display header
+        -->\r\n            <div id=\"Application\">\r\n                <h3>\r\n                    \r\n
+        \                   \r\n                        Planning Applications\r\n
+        \                   \r\n                    <span>(0)</span>\r\n                </h3>\n\r\n\r\n
+        \               <!-- Display each item -->\r\n                \r\n            </div>\r\n\r\n
+        \       \r\n            \r\n            \r\n\r\n            <!-- Display header
+        -->\r\n            <div id=\"Appeal\">\r\n                <h3>\r\n                    \r\n
+        \                   \r\n                        Planning Appeals\r\n                    \r\n
+        \                   <span>(0)</span>\r\n                </h3>\n\r\n\r\n                <!--
+        Display each item -->\r\n                \r\n            </div>\r\n\r\n        \r\n
+        \           \r\n            \r\n\r\n            <!-- Display header -->\r\n
+        \           <div id=\"Enforcement\">\r\n                <h3>\r\n                    \r\n
+        \                   \r\n                        Planning Enforcements\r\n
+        \                   \r\n                    <span>(0)</span>\r\n                </h3>\n\r\n\r\n
+        \               <!-- Display each item -->\r\n                \r\n            </div>\r\n\r\n
+        \       \r\n            \r\n            \r\n\r\n            <!-- Display header
+        -->\r\n            <div id=\"Property\">\r\n                <h3>\r\n                    \r\n
+        \                   \r\n                        Properties\r\n                    \r\n
+        \                   <span>(1)</span>\r\n                </h3>\n\r\n\r\n                <!--
+        Display each item -->\r\n                \r\n                    <ul>\r\n
+        \                       \r\n                            <li>\r\n                                \r\n
+        \                               \r\n                                \r\n\r\n
+        \                               <a href=\"/online-applications/propertyDetails.do?previousCaseType=Application&amp;keyVal=_CARDIFF_PROPLPI_8256_4&amp;previousCaseNumber=19%2F00257%2FMNR&amp;activeTab=summary&amp;previousKeyVal=_CARDIFF_DCAPR_126502\">\r\n
+        \                                   BANNATYNE HEALTH CLUB, PARC TY GLAS, LLANISHEN,
+        CARDIFF, CF14 5DU\r\n                                </a>\r\n\r\n                                <p
+        class=\"metaInfo\">\r\n\r\n                                \r\n\r\n                                \r\n\r\n
+        \                               \r\n                                \r\n                                \r\n
+        \                              </p>\r\n                            </li>\r\n
+        \                       \r\n                    </ul>\r\n                \r\n
+        \           </div>\r\n\r\n        \r\n\r\n    </div>\r\n    </div>\r\n\r\n<!--
+        #EndEditable -->\r\n                    <!-- #BeginEditable \"pagefoot\" --><!--
+        #EndEditable -->\r\n                </div>\r\n                <!-- END WAM
+        CONTENT -->\r\n                \r\n                <p id=\"poweredBy\"><a
+        href=\"http://www.idoxgroup.com/\" target=\"_blank\" title=\"This link will
+        open a new window\"><img src=\"/online-applications-skin/images/idox.gif\"
+        alt=\"an Idox solution\" /></a></p>\r\n            </div>\t\r\n\t\t\t<div
+        id=\"footer\">\r\n\t\t\t\t<div class=\"container\">\t\t\t\t\t\r\n\t\t\t\t\t<div
+        id=\"links\">\r\n\t\t\t\t\t\t<ul>\r\n\t\t\t\t\t\t\t<li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Site_Map/Pages/default.aspx\">Site
+        map</a></li><li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Cookies/Pages/Cookies.aspx\">Cookies</a></li><li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/New_Disclaimer/Pages/default.aspx\">Disclaimer</a></li>\r\n\t\t\t\t\t\t</ul>\r\n\t\t\t\t\t</div>\r\n\t\t\t\t\t<div
+        class=\"clear\"></div>\r\n\t\t\t\t</div>\r\n\t\t\t</div>\r\n\t\t\t<div id=\"footerBottom\">\r\n\t\t\t
+        \   <div class=\"container\">\r\n\t\t\t        <div id=\"footercontent\"><p>&copy;
+        <script type=\"text/javascript\">document.write(new Date().getFullYear());</script>
+        Cardiff Council</p></div>\r\n\t\t\t        <div class=\"clear\"></div>\r\n\t\t\t
+        \   </div>\r\n\t\t\t</div>\r\n        </div>    \r\n    </div>  \r\n    <!--
+        IDOX PA END -->           \r\n\t\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Mon, 15 Apr 2019 11:15:23 GMT
+- request:
+    method: get
+    uri: https://planningonline.cardiff.gov.uk/online-applications/propertyDetails.do?activeTab=summary&keyVal=_CARDIFF_PROPLPI_8256_4&previousCaseNumber=19/00257/MNR&previousCaseType=Application&previousKeyVal=_CARDIFF_DCAPR_126502
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip,deflate,identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mechanize/2.7.6 Ruby/2.6.2p47 (http://github.com/sparklemotion/mechanize/)
+      Accept-Charset:
+      - ISO-8859-1,utf-8;q=0.7,*;q=0.7
+      Accept-Language:
+      - en-us,en;q=0.5
+      Cookie:
+      - JSESSIONID=ss9pKoHL32yHmhJQONSykek96zXCSSZ75skxJ5v1.vmidoxweblve; WSLang-CFC001=EN
+      Host:
+      - planningonline.cardiff.gov.uk
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '300'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - text/html; charset=UTF-8
+      Expires:
+      - Mon, 15 Apr 2019 11:15:56 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ua-Compatible:
+      - IE=edge
+      Server:
+      - Apache
+      Set-Cookie:
+      - WSLang-CFC001=EN; expires=Mon, 15-Apr-2069 11:15:54 GMT; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 15 Apr 2019 11:15:56 GMT
+      Content-Length:
+      - '13654'
+    body:
+      encoding: UTF-8
+      string: "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n    \n\n    \n\n<!DOCTYPE html PUBLIC
+        \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\r\n<html
+        lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\r\n<head>\r\n\r\n\t<!--
+        #BeginEditable \"doctitle\" -->\r\n    <title>\r\n    _CARDIFF_PROPLPI_8256_4\r\n
+        \   |\r\n    \r\n\r\n    \r\n\r\n    \r\n\r\n    \r\n    \r\n    \r\n    \r\n
+        \   \r\n        \r\n        BANNATYNE HEALTH CLUB, PARC TY GLAS, LLANISHEN,
+        CARDIFF, CF14 5DU\r\n    \r\n    \r\n    </title>\r\n<!-- #EndEditable -->\r\n
+        \   <!-- #BeginEditable \"metatags\" --><!-- #EndEditable -->\r\n\t\r\n    <meta
+        http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" />\r\n\t\r\n\t<!--
+        Customer metatags -->\r\n\t\r\n\t\r\n\t<!-- Favicon link -->\r\n    <link
+        rel=\"icon\" href=\"/online-applications-skin/images/cardiff/favicon.ico\"
+        type=\"image/x-icon\" />\r\n\t\r\n    <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/screen.css\"
+        type=\"text/css\" media=\"screen,projection\" />\r\n    <link rel=\"stylesheet\"
+        href=\"/online-applications-skin/styles/theme1.css\" type=\"text/css\"/>\t\r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/print.css\"
+        type=\"text/css\" media=\"print\" />   \r\n\r\n    <script type=\"text/javascript\"
+        src=\"/online-applications-skin/scripts/jquery.min.js\"></script>\r\n    <script
+        type=\"text/javascript\" src=\"/online-applications-skin/scripts/jquery.toolbar.idox.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/common.js\"></script>\r\n
+        \       \r\n\t<!-- Customer Analytics Script -->\r\n\t\r\n\t\r\n    <script
+        type=\"text/javascript\">\r\n    \t$('html').addClass('js');\r\n    \t$(document).ready(function(){\r\n
+        \   \t\t$('.main#apply>span:first-child').attr('tabindex', '0')\r\n    \t});\r\n
+        \   </script>\r\n    \r\n    <!-- #BeginEditable \"mobile\" --><!-- #EndEditable
+        -->\r\n    <!-- #BeginEditable \"head\" --><!-- #EndEditable -->\r\n    <!--
+        #BeginEditable \"webapp\" --><!-- #EndEditable -->\r\n\r\n</head>\r\n<body>\r\n\r\n
+        \   <a href=\"#pageheading\" class=\"sr-only\">Skip to main content</a>\r\n\r\n
+        \   <!-- IDOX PA START -->\r\n    <div id=\"idox\">\r\n        <div id=\"pa\">
+        \r\n\t\t\t<div id=\"header\"><!-- Selector: Selector 1 -->\r\n<style>\r\n#langStyle{float:right;
+        margin-top: 10px; margin-right: 30px; background:transparent; font-size:13px;
+        cursor:pointer; border:1px solid #fff !important;border-radius:2px; z-index:999;
+        background-color: #fff; padding:2px;}\r\n#langStyle:hover{text-decoration:
+        underline;}</style>\r\n<div>\r\n\r\n<!--CYS--><a id=\"langStyle\" href=\"/online-applications/propertyDetails.do?previousCaseType=Application&keyVal=_CARDIFF_PROPLPI_8256_4&previousCaseNumber=19%2f00257%2fMNR&activeTab=summary&previousKeyVal=_CARDIFF_DCAPR_126502&lang=CY\">Cymraeg</a><!--CYE-->\r\n</div>\r\n\t\t\t\t<div
+        class=\"container\">\r\n\t\t\t\t\t<div id=\"logo\"><a href=\"https://www.cardiff.gov.uk/\"
+        title=\"Cardiff Council home page\"><img src=\"/online-applications-skin/images/cardiff/logo.png\"
+        alt=\"Council logo\" /><span class=\"sr-only\">Cardiff Council</span></a></div>\r\n\t\t\t\t\t<div
+        id=\"headertitle\"><span></span></div>\r\n\t\t\t\t\t<div class=\"clear\"></div>\r\n\t\t\t\t</div>\t\r\n\t\t\t</div>\r\n\t\t\t<div
+        id=\"breadcrumbs\" class=\"container\">\r\n\t\t\t\t<ul>\r\n\t\t\t\t\t\r\n\t\t\t\t</ul>\r\n\t\t\t</div>\r\n
+        \           <div class=\"container\">\r\n                <div id=\"toolbar\"
+        class=\"nojs\">\r\n                    <ul>\t\r\n                        <li
+        id=\"search\" class=\"main\"><span tabindex=\"0\">Search&nbsp;</span><span
+        class=\"caret\"></span>\r\n   \t\t\t\t\t\t\t<ul>\t\r\n\t\t\t\t\t\t\t\t<!--
+        #BeginLibraryItem \"/Library/searchModulesNavItems.lbi\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \       \r\n            <li id=\"planLinks\">\r\n                <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\"
+        >\r\n                    <span>Planning</span>\r\n                </a>\r\n
+        \               <ul>\r\n                    <li id=\"planBasicSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\">\r\n
+        \                           Simple Search\r\n                        </a>\r\n
+        \                   </li>\r\n\r\n                    <li id=\"planAdvancedSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=advanced&amp;searchType=Application\">\r\n
+        \                           Advanced\r\n                        </a>\r\n                    </li>\r\n
+        \                   <li id=\"planListSearch\">\r\n                        <a
+        href=\"/online-applications/search.do?action=weeklyList&amp;searchType=Application\">\r\n
+        \                           Weekly/Monthly Lists\r\n                        </a>\r\n
+        \                   </li>\r\n                    <li id=\"planPropertySearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=property&amp;type=custom\">\r\n
+        \                           Property Search\r\n                        </a>\r\n
+        \                   </li>\r\n\t\t\t\t\t\r\n                    \r\n\t\t\t\t\t\r\n
+        \               </ul>\r\n            </li>\r\n        \r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        <!-- #EndLibraryItem -->\r\n                        \t</ul>\r\n\t\t\t\t\t\t</li>\r\n
+        \                       <!-- #BeginEditable \"applicationForms\" -->\n\n\n\n\n\n
+        \  \n<!-- #EndEditable -->   \t\t\t\t\r\n                        <li id=\"myprofile\"
+        class=\"main\"><span tabindex=\"0\">My Profile&nbsp;</span><span class=\"caret\"></span>\r\n
+        \                           <ul>\r\n                              <!-- #BeginLibraryItem
+        \"/Library/consulteeInTrayNavItem.lbi\" -->\n\n\n\n\n\n\n    <!-- #EndLibraryItem
+        -->\r\n                                <li><a href=\"/online-applications/registered/displayUserDetails.do\">Profile
+        Details</a></li>\r\n                                <li><a href=\"/online-applications/registered/savedSearch.do?action=display\">Saved
+        Searches</a></li>\r\n                                <li><a href=\"/online-applications/registered/userAdmin.do?action=showNotifiedApplications\">Notified
+        Applications</a></li>\r\n                                <li><a href=\"/online-applications/registered/trackedApplication.do?action=display\">Tracked
+        Applications</a></li>\r\n                                <!-- #BeginEditable
+        \"formSubmissions\" -->\n\n\n\n\n\n\n\n\n<!-- #EndEditable -->    \t\r\n                            </ul>\r\n
+        \                       </li>\r\n                        <li id=\"loginLink\"
+        class=\"main\"><!-- #BeginEditable \"loginlogout\" -->\n\n\n\n\n\n\n\n\n\n\n\t<a
+        href=\"/online-applications/registered/userAdmin.do\">Login</a>\n<!-- #EndEditable
+        --></li>\r\n                        <!-- #BeginEditable \"register\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \  \r\n\r\n\r\n\t<li id=\"register\">\r\n        <a href=\"/online-applications/registrationWizard.do?action=start\">Register</a>\r\n\t</li>\r\n\r\n<!--
+        #EndEditable -->\r\n                        <!-- #BeginLibraryItem \"/Library/applyOnlineNavItems.lbi\"
+        -->\r\n\r\n\r\n\r\n\r\n\r\n<!-- #EndLibraryItem -->\r\n                    </ul>\r\n
+        \   \t\t\t</div>\r\n                \r\n                <div id=\"pageheading\">\r\n
+        \                   <h1><!-- #BeginEditable \"pageheading\" -->Property Address<!--
+        #EndEditable --></h1>\r\n                    <!-- #BeginEditable \"helplink\"
+        -->\r\n<p class=\"pagehelp\">\r\n\t<a title=\"Help with this page (opens in
+        a new window)\" rel=\"external\" target=\"_blank\" href=\"/online-applications/help/pagehelp/properties.htm\">\r\n\t\tHelp
+        with this page\r\n\t<span> (opens in a new window)</span>\r\n\t</a>\r\n</p>\r\n<!--
+        #EndEditable -->\r\n                </div>\r\n        \r\n                <!--
+        START WAM CONTENT -->\r\n                <div class=\"content\">\r\n                    <!--
+        #BeginEditable \"errormsg\" -->\n        \n        \n\n        \n        \n
+        \   <!-- #EndEditable -->\r\n                    <!-- #BeginEditable \"pagehead\"
+        -->\r\n\r\n    <div class=\"addressCrumb\">\r\n        <span class=\"caseNumber\">\r\n
+        \           \r\n                200001097060 \r\n            \r\n\r\n            \r\n
+        \       </span>\r\n\r\n        <span class=\"divider1\">|</span>\r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        \r\n\r\n        \r\n        \r\n        \r\n        \r\n
+        \       \r\n            \r\n            <span class=\"address\">\r\n                BANNATYNE
+        HEALTH CLUB, PARC TY GLAS, LLANISHEN, CARDIFF, CF14 5DU\r\n            </span>\r\n
+        \       \r\n        \r\n    </div>\r\n\r\n\r\n    <div id=\"applicationTools\">\r\n
+        \       <ul>\r\n            \r\n            \r\n\r\n            \r\n\r\n            \r\n
+        \           \r\n                <li>\r\n                    <a href=\"/online-applications/applicationDetails.do?keyVal=_CARDIFF_DCAPR_126502&amp;activeTab=summary\"
+        id=\"searchresultsback\">\r\n                        Planning Application\r\n
+        \                       \r\n                        \r\n                            19/00257/MNR\r\n
+        \                       \r\n                    </a>\r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n            \r\n            \r\n\r\n\r\n
+        \           \r\n                \r\n             \r\n            \r\n\r\n
+        \           \r\n            \r\n                \r\n            \r\n            \r\n
+        \           \r\n            <li>\r\n                <a href=\"/online-applications/propertyDetails.do?activeTab=printPreview&amp;keyVal=_CARDIFF_PROPLPI_8256_4\"
+        id=\"print\" rel=\"external\">\r\n                    <img src=\"/online-applications-skin/images/button_print.gif\"
+        alt=\"Print summary icon\" width=\"53\" height=\"22\" border=\"0\"/>\r\n                </a>\r\n
+        \           </li>\r\n            \r\n\r\n            \r\n        </ul>\r\n\r\n
+        \   </div>\r\n\r\n\r\n     \r\n\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabs\" -->\r\n    \r\n    <ul class=\"tabs\">\r\n\r\n        \r\n\r\n
+        \           \r\n                \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/propertyDetails.do?activeTab=summary&amp;keyVal=_CARDIFF_PROPLPI_8256_4\"
+        id=\"tab_summary\" class=\"active\">\r\n                        <span>\r\n
+        \                           Address\r\n                            \r\n                        </span>\r\n
+        \                   </a>\r\n\r\n                    \r\n                    \r\n
+        \                   \r\n                        \r\n                        \r\n
+        \                   \r\n                </li>\r\n            \r\n\r\n            \r\n\r\n
+        \       \r\n\r\n            \r\n                \r\n                <li>\r\n\r\n
+        \                    \r\n                    <a href=\"/online-applications/propertyDetails.do?activeTab=relatedCases&amp;keyVal=_CARDIFF_PROPLPI_8256_4\"
+        id=\"tab_relatedCases\">\r\n                        <span>\r\n                            Property
+        History\r\n                            \r\n                                \r\n
+        \                               (7)\r\n                            \r\n                        </span>\r\n
+        \                   </a>\r\n\r\n                    \r\n                    \r\n
+        \                   \r\n                </li>\r\n            \r\n\r\n            \r\n\r\n
+        \       \r\n\r\n            \r\n                \r\n                <li>\r\n\r\n
+        \                    \r\n                    <a href=\"/online-applications/propertyDetails.do?activeTab=constraints&amp;keyVal=_CARDIFF_PROPLPI_8256_4\"
+        id=\"tab_constraints\">\r\n                        <span>\r\n                            Constraints\r\n
+        \                           \r\n                                \r\n                                (1)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n\r\n
+        \           \r\n\r\n        \r\n    </ul>\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabsubnav\" --><!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"pagebody\" -->\n    \r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\n
+        \   \n        \n        \n    \n\n    \n    \n    \n    \n    \n        \n
+        \       \n    \n\n    <div class=\"tabcontainer toplevel\">\n\n        \n
+        \       \n        \n            \n            <table id=\"propertyAddress\"
+        summary=\"Property address\">\r\n<tr class=\"row0\">\r\n<th scope=\"row\">UPRN:</th>\r\n<td>200001097060</td>\r\n</tr>\r\n<tr
+        class=\"row1\">\r\n<th scope=\"row\">Full Address:</th>\r\n<td>BANNATYNE HEALTH
+        CLUB, PARC TY GLAS, LLANISHEN, CARDIFF, CF14 5DU</td>\r\n</tr>\r\n<tr class=\"row0\">\r\n<th
+        scope=\"row\">Property Description:</th>\r\n<td>BANNATYNE HEALTH CLUB</td>\r\n</tr>\r\n<tr
+        class=\"row1\">\r\n<th scope=\"row\">Property Number:</th>\r\n<td/>\r\n</tr>\r\n<tr
+        class=\"row0\">\r\n<th scope=\"row\">Street:</th>\r\n<td>PARC TY GLAS</td>\r\n</tr>\r\n<tr
+        class=\"row1\">\r\n<th scope=\"row\">Town:</th>\r\n<td>CARDIFF</td>\r\n</tr>\r\n<tr
+        class=\"row0\">\r\n<th scope=\"row\">Postcode:</th>\r\n<td>CF14 5DU</td>\r\n</tr>\r\n<tr
+        class=\"row1\">\r\n<th scope=\"row\">Ward:</th>\r\n<td>LLANISHEN</td>\r\n</tr>\r\n<tr
+        class=\"row0\">\r\n<th scope=\"row\">Parish:</th>\r\n<td/>\r\n</tr>\r\n</table>\r\n\n
+        \       \n\n        \n        \n\n        \n        \n            \n        \n\n
+        \   </div>\n<!-- #EndEditable -->\r\n                    <!-- #BeginEditable
+        \"pagefoot\" --><!-- #EndEditable -->\r\n                </div>\r\n                <!--
+        END WAM CONTENT -->\r\n                \r\n                <p id=\"poweredBy\"><a
+        href=\"http://www.idoxgroup.com/\" target=\"_blank\" title=\"This link will
+        open a new window\"><img src=\"/online-applications-skin/images/idox.gif\"
+        alt=\"an Idox solution\" /></a></p>\r\n            </div>\r\n\t\t\t<div id=\"footer\">\r\n\t\t\t\t<div
+        class=\"container\">\t\t\t\t\t\r\n\t\t\t\t\t<div id=\"links\">\r\n\t\t\t\t\t\t<ul>\r\n\t\t\t\t\t\t\t<li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/Site_Map/Pages/default.aspx\">Site
+        map</a></li><li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Cookies/Pages/Cookies.aspx\">Cookies</a></li><li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/New_Disclaimer/Pages/default.aspx\">Disclaimer</a></li>\r\n\t\t\t\t\t\t</ul>\r\n\t\t\t\t\t</div>\r\n\t\t\t\t\t<div
+        class=\"clear\"></div>\r\n\t\t\t\t</div>\r\n\t\t\t</div>\r\n\t\t\t<div id=\"footerBottom\">\r\n\t\t\t
+        \   <div class=\"container\">\r\n\t\t\t        <div id=\"footercontent\"><p>&copy;
+        <script type=\"text/javascript\">document.write(new Date().getFullYear());</script>
+        Cardiff Council</p></div>\r\n\t\t\t        <div class=\"clear\"></div>\r\n\t\t\t
+        \   </div>\r\n\t\t\t</div>\r\n        </div>\r\n    </div>\r\n    <!-- IDOX
+        PA END -->\r\n\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Mon, 15 Apr 2019 11:15:25 GMT
+- request:
+    method: get
+    uri: https://planningonline.cardiff.gov.uk/online-applications/applicationDetails.do?activeTab=summary&keyVal=_CARDIFF_DCAPR_126451
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip,deflate,identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mechanize/2.7.6 Ruby/2.6.2p47 (http://github.com/sparklemotion/mechanize/)
+      Accept-Charset:
+      - ISO-8859-1,utf-8;q=0.7,*;q=0.7
+      Accept-Language:
+      - en-us,en;q=0.5
+      Cookie:
+      - JSESSIONID=ss9pKoHL32yHmhJQONSykek96zXCSSZ75skxJ5v1.vmidoxweblve; WSLang-CFC001=EN
+      Host:
+      - planningonline.cardiff.gov.uk
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '300'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - text/html; charset=UTF-8
+      Expires:
+      - Mon, 15 Apr 2019 11:16:11 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ua-Compatible:
+      - IE=edge
+      Server:
+      - Apache
+      Set-Cookie:
+      - WSLang-CFC001=EN; expires=Mon, 15-Apr-2069 11:16:07 GMT; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 15 Apr 2019 11:16:11 GMT
+      Content-Length:
+      - '28395'
+    body:
+      encoding: UTF-8
+      string: "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n    \n\n    \n\n<!DOCTYPE html PUBLIC
+        \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\r\n<html
+        lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\r\n<head>\r\n\t\r\n\t<!--
+        #BeginEditable \"doctitle\" -->\r\n    <title>\r\n    19/00214/DCH\r\n    |\r\n
+        \   \r\n        REMOVE EXISTING DECKING AT REAR AND REPLACE WITH GROUND LEVEL
+        AND RAISED PATIOS\r\n        \r\n        |\r\n        \r\n    \r\n\r\n    \r\n\r\n
+        \   \r\n\r\n    \r\n    \r\n    \r\n    \r\n    \r\n        \r\n        17
+        PANTGLAS, PENTYRCH, CARDIFF, CF15 9TH\r\n    \r\n    \r\n    </title>\r\n<!--
+        #EndEditable -->\r\n    <!-- #BeginEditable \"metatags\" --><!-- #EndEditable
+        -->\r\n\t\r\n    <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
+        />\r\n\t\r\n\t<!-- Customer metatags -->\r\n\t\r\n\t\r\n\t<!-- Favicon link
+        -->\r\n    <link rel=\"icon\" href=\"/online-applications-skin/images/cardiff/favicon.ico\"
+        type=\"image/x-icon\" />\r\n\t\r\n    <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/screen.css\"
+        type=\"text/css\" media=\"screen,projection\" />\r\n    <link rel=\"stylesheet\"
+        href=\"/online-applications-skin/styles/theme1.css\" type=\"text/css\"/>    \r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/print.css\"
+        type=\"text/css\" media=\"print\" />\r\n\t\r\n    <script type=\"text/javascript\"
+        src=\"/online-applications-skin/scripts/jquery.min.js\"></script>\r\n    <script
+        type=\"text/javascript\" src=\"/online-applications-skin/scripts/jquery.toolbar.idox.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/common.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/checkbox.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/amplify.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/createCommentCookie.js\"></script>\r\n
+        \       \r\n\t<!-- Customer Analytics Script -->\r\n\t\r\n\t\r\n    <script
+        type=\"text/javascript\">\r\n    \t$('html').addClass('js');\r\n    \t$(document).ready(function(){\r\n
+        \   \t\t$('.main#apply>span:first-child').attr('tabindex', '0')\r\n    \t});\r\n
+        \   </script>\r\n    \r\n    <!-- #BeginEditable \"mobile\" --><!-- #EndEditable
+        -->\r\n    <!-- #BeginEditable \"head\" -->\r\n\t<script type=\"text/javascript\">\r\n\t
+        \   jQuery(document).ready(function() {\t\r\n\t\t\tjQuery('#pa').before('<img
+        src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\" id=\"preload\"
+        />');\r\n\t\t\tjQuery('#preload').hide();\r\n\t\t\tjQuery('.tabs a#tab_documents').click(
+        function(event) {\r\n\t\t\t\t  window.clearTimeout(window.timeOutId);\r\n\t\t\t\t
+        \ window.timeOutId = window.setTimeout(function() {\r\n\t\t\t\t\t\tjQuery('.content').before('<div
+        id=\"overlay\"></div><div id=\"loading\"><div id=\"message\">Loading. Please
+        wait.... <img src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\"
+        height=\"19\" width=\"220\" style=\"background:#fff;\" /></div></div>');\r\n\t\t\t\t
+        \ },10);\r\n\t\t\t\t});\r\n\t\t\tjQuery('p.associateddocument a').click( function(event)
+        {\r\n\t\t\t\t  window.clearTimeout(window.timeOutId);\r\n\t\t\t\t  window.timeOutId
+        = window.setTimeout(function() {\r\n\t\t\t\t\t\tjQuery('.content').before('<div
+        id=\"overlay\"></div><div id=\"loading\"><div id=\"message\">Loading. Please
+        wait.... <img src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\"
+        height=\"19\" width=\"220\" style=\"background:#fff;\" /></div></div>');\r\n\t\t\t\t
+        \ },10);\r\n\t\t\t\t});\r\n\r\n\t\t});\r\n    </script>\r\n    \r\n    <link
+        rel=\"stylesheet\" href=\"/online-applications-skin/styles/simple_social_share.min.css\"
+        type=\"text/css\"/>\r\n    <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/simple_social_share.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\">\r\n        $(document).ready(function(){\r\n
+        \           \r\n            \r\n            $(\"share-button\").simpleSocialShare({\r\n
+        \               sites: \"twitter,email\", \r\n                url: window.location.href,
+        \r\n                title: \"Online application\", \r\n                description:
+        \"Please look at this Planning Application: \", \r\n                shareType:
+        \"button\", \r\n                buttonSide: \"left\", \r\n                orientation:
+        \"horizontal\"\r\n            });\r\n        });\r\n\t</script>\r\n\t<!--
+        #EndEditable -->\r\n    <!-- #BeginEditable \"webapp\" --><!-- #EndEditable
+        -->\r\n\r\n</head>\r\n<body>\r\n\r\n    <a href=\"#pageheading\" class=\"sr-only\">Skip
+        to main content</a>\r\n\r\n    <!-- IDOX PA START -->\r\n    <div id=\"idox\">\r\n
+        \       <div id=\"pa\">\r\n\t\t\t<div id=\"header\"><!-- Selector: Selector
+        1 -->\r\n<style>\r\n#langStyle{float:right; margin-top: 10px; margin-right:
+        30px; background:transparent; font-size:13px; cursor:pointer; border:1px solid
+        #fff !important;border-radius:2px; z-index:999; background-color: #fff; padding:2px;}\r\n#langStyle:hover{text-decoration:
+        underline;}</style>\r\n<div>\r\n\r\n<!--CYS--><a id=\"langStyle\" href=\"/online-applications/applicationDetails.do?keyVal=_CARDIFF_DCAPR_126451&activeTab=summary&lang=CY\">Cymraeg</a><!--CYE-->\r\n</div>\r\n\t\t\t\t<div
+        class=\"container\">\r\n\t\t\t\t\t<div id=\"logo\"><a href=\"https://www.cardiff.gov.uk/\"
+        title=\"Cardiff Council home page\"><img src=\"/online-applications-skin/images/cardiff/logo.png\"
+        alt=\"Council logo\" /><span class=\"sr-only\">Cardiff Council</span></a></div>\r\n\t\t\t\t\t<div
+        id=\"headertitle\"><span></span></div>\r\n\t\t\t\t\t<div class=\"clear\"></div>\r\n\t\t\t\t</div>\t\r\n\t\t\t</div>\r\n\t\t\t<div
+        id=\"breadcrumbs\" class=\"container\">\r\n\t\t\t\t<ul>\r\n\t\t\t\t\t\r\n\t\t\t\t</ul>\r\n\t\t\t</div>\r\n
+        \           <div class=\"container\">\r\n       \t\t\t<div id=\"toolbar\"
+        class=\"nojs\">\r\n                    <ul>\t\r\n                        <li
+        id=\"search\" class=\"main\"><span tabindex=\"0\">Search&nbsp;</span><span
+        class=\"caret\"></span>\r\n   \t\t\t\t\t\t\t<ul>\t\r\n\t\t\t\t\t\t\t\t<!--
+        #BeginLibraryItem \"/Library/searchModulesNavItems.lbi\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \       \r\n            <li id=\"planLinks\">\r\n                <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\"
+        >\r\n                    <span>Planning</span>\r\n                </a>\r\n
+        \               <ul>\r\n                    <li id=\"planBasicSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\">\r\n
+        \                           Simple Search\r\n                        </a>\r\n
+        \                   </li>\r\n\r\n                    <li id=\"planAdvancedSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=advanced&amp;searchType=Application\">\r\n
+        \                           Advanced\r\n                        </a>\r\n                    </li>\r\n
+        \                   <li id=\"planListSearch\">\r\n                        <a
+        href=\"/online-applications/search.do?action=weeklyList&amp;searchType=Application\">\r\n
+        \                           Weekly/Monthly Lists\r\n                        </a>\r\n
+        \                   </li>\r\n                    <li id=\"planPropertySearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=property&amp;type=custom\">\r\n
+        \                           Property Search\r\n                        </a>\r\n
+        \                   </li>\r\n\t\t\t\t\t\r\n                    \r\n\t\t\t\t\t\r\n
+        \               </ul>\r\n            </li>\r\n        \r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        <!-- #EndLibraryItem -->\r\n                        \t</ul>\r\n\t\t\t\t\t\t</li>\r\n
+        \                       <!-- #BeginEditable \"applicationForms\" -->\n\n\n\n\n\n
+        \  \n<!-- #EndEditable -->   \t\t\t\t\r\n                        <li id=\"myprofile\"
+        class=\"main\"><span tabindex=\"0\">My Profile&nbsp;</span><span class=\"caret\"></span>\r\n
+        \                           <ul>\r\n                              <!-- #BeginLibraryItem
+        \"/Library/consulteeInTrayNavItem.lbi\" -->\n\n\n\n\n\n\n    <!-- #EndLibraryItem
+        -->\r\n                                <li><a href=\"/online-applications/registered/displayUserDetails.do\">Profile
+        Details</a></li>\r\n                                <li><a href=\"/online-applications/registered/savedSearch.do?action=display\">Saved
+        Searches</a></li>\r\n                                <li><a href=\"/online-applications/registered/userAdmin.do?action=showNotifiedApplications\">Notified
+        Applications</a></li>\r\n                                <li><a href=\"/online-applications/registered/trackedApplication.do?action=display\">Tracked
+        Applications</a></li>\r\n                                <!-- #BeginEditable
+        \"formSubmissions\" -->\n\n\n\n\n\n\n\n\n<!-- #EndEditable -->    \t\r\n                            </ul>\r\n
+        \                       </li>\r\n                        <li id=\"loginLink\"
+        class=\"main\"><!-- #BeginEditable \"loginlogout\" -->\n\n\n\n\n\n\n\n\n\n\n\t<a
+        href=\"/online-applications/registered/userAdmin.do\">Login</a>\n<!-- #EndEditable
+        --></li>\r\n                        <!-- #BeginEditable \"register\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \  \r\n\r\n\r\n\t<li id=\"register\">\r\n        <a href=\"/online-applications/registrationWizard.do?action=start\">Register</a>\r\n\t</li>\r\n\r\n<!--
+        #EndEditable -->\r\n                        <!-- #BeginLibraryItem \"/Library/applyOnlineNavItems.lbi\"
+        -->\r\n\r\n\r\n\r\n\r\n\r\n<!-- #EndLibraryItem -->\r\n                    </ul>\r\n
+        \   \t\t\t</div>\r\n\r\n    \t\t\t<!-- #BeginEditable \"headlinenews\" --><!--
+        #EndEditable -->\r\n                 \r\n                <div id=\"pageheading\">\r\n
+        \                   <h1><strong>Planning</strong>&nbsp;&ndash;&nbsp;<!-- #BeginEditable
+        \"pageheading\" -->Application Summary<!-- #EndEditable --></h1>\r\n                    <!--
+        #BeginEditable \"helplink\" -->\r\n<p class=\"pagehelp\">\r\n\t<a title=\"Help
+        with this page (opens in a new window)\" rel=\"external\" target=\"_blank\"
+        href=\"/online-applications/help/pagehelp/applications.htm\">\r\n\t\tHelp
+        with this page\r\n\t<span> (opens in a new window)</span>\r\n\t</a>\r\n</p>\r\n<!--
+        #EndEditable -->\r\n                </div>\r\n                \r\n                <!--
+        START WAM CONTENT -->\r\n                <div class=\"content\">\r\n                    <!--
+        #BeginEditable \"errormsg\" -->\n        \n        \n\n        \n        \n
+        \   <!-- #EndEditable -->\r\n                    <!-- #BeginEditable \"pagehead\"
+        -->\r\n\r\n    <div class=\"addressCrumb\">\r\n        <span class=\"caseNumber\">\r\n
+        \           \r\n\r\n            \r\n                19/00214/DCH\r\n            \r\n
+        \       </span>\r\n\r\n        <span class=\"divider1\">|</span>\r\n\r\n        \r\n
+        \           <span class=\"description\">\r\n                REMOVE EXISTING
+        DECKING AT REAR AND REPLACE WITH GROUND LEVEL AND RAISED PATIOS\r\n            </span>\r\n
+        \           \r\n                <span class=\"divider2\">|</span>\r\n            \r\n
+        \       \r\n\r\n        \r\n\r\n        \r\n\r\n        \r\n        \r\n        \r\n
+        \       \r\n        \r\n            \r\n            <span class=\"address\">\r\n
+        \               17 PANTGLAS, PENTYRCH, CARDIFF, CF15 9TH\r\n            </span>\r\n
+        \       \r\n        \r\n    </div>\r\n\r\n\r\n    <div id=\"applicationTools\">\r\n
+        \       <ul>\r\n            \r\n            \r\n                \r\n                    \r\n
+        \                       \r\n                            \r\n                            \r\n
+        \                               \r\n                                    <li>\r\n
+        \                                       <a href=\"/online-applications/searchResultsBack.do?action=back\"
+        id=\"searchresultsback\">Back to search results</a>\r\n                                    </li>\r\n
+        \                               \r\n                            \r\n                        \r\n
+        \                   \r\n                    \r\n                    \r\n                \r\n
+        \           \r\n\r\n            \r\n\r\n            \r\n            \r\n\r\n
+        \           \r\n\r\n            \r\n            \r\n                \r\n                    <li>\r\n
+        \                       <form name=\"trackForm\" method=\"post\" action=\"/online-applications/registered/trackedApplicationSubmit.do?action=track\"><input
+        type=\"hidden\" name=\"org.apache.struts.taglib.html.TOKEN\" value=\"a3a9cd286e4e2ea2199148de99ea4f70\"
+        />\r\n                            <input type=\"hidden\" name=\"caseNo\" value=\"19/00214/DCH\"
+        />\r\n                            <input type=\"hidden\" name=\"caseType\"
+        value=\"Application\" />\r\n                            <input type=\"hidden\"
+        name=\"address\" value=\"17 PANTGLAS, PENTYRCH, CARDIFF, CF15 9TH\" />\r\n
+        \                           <input type=\"hidden\" name=\"description\" value=\"REMOVE
+        EXISTING DECKING AT REAR AND REPLACE WITH GROUND LEVEL AND RAISED PATIOS\"
+        />\r\n                            <input type=\"hidden\" name=\"status\" value=\"Decided\"
+        />\r\n                            <input type=\"hidden\" name=\"trackingStatus\"
+        value=\"Decided\" />\r\n                            <input type=\"hidden\"
+        name=\"caseTechnicalKey\" value=\"_CARDIFF_DCAPR_126451\" />\r\n                            <input
+        class=\"casefiletrack\"\r\n                                   src=\"/online-applications-skin/images/button_track.gif\"\r\n
+        \                                  type=\"image\"\r\n                                   name=\"submit\"\r\n
+        \                                  altKey=\"casedetails.track\"\r\n                                   title=\"Get
+        informed when this item is updated\"/>\r\n                        </form>\r\n
+        \                   </li>\r\n                \r\n\r\n                \r\n
+        \           \r\n\r\n\r\n            \r\n                \r\n             \r\n
+        \           \r\n\r\n            \r\n            \r\n                \r\n            \r\n
+        \           \r\n            \r\n            <li>\r\n                <a href=\"/online-applications/applicationDetails.do?activeTab=printPreview&amp;keyVal=_CARDIFF_DCAPR_126451\"
+        id=\"print\" rel=\"external\">\r\n                    <img src=\"/online-applications-skin/images/button_print.gif\"
+        alt=\"Print summary icon\" width=\"53\" height=\"22\" border=\"0\"/>\r\n                </a>\r\n
+        \           </li>\r\n            \r\n\r\n            \r\n        </ul>\r\n\r\n
+        \   </div>\r\n\r\n\r\n     \r\n\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabs\" -->\r\n    \r\n    <ul class=\"tabs\">\r\n\r\n        \r\n\r\n
+        \           \r\n                \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/applicationDetails.do?activeTab=summary&amp;keyVal=_CARDIFF_DCAPR_126451\"
+        id=\"tab_summary\" class=\"active\">\r\n                        <span>\r\n
+        \                           Details\r\n                            \r\n                        </span>\r\n
+        \                   </a>\r\n\r\n                    \r\n                    \r\n
+        \                   \r\n                        \r\n                        \r\n\r\n
+        \                           <ul class=\"subtabs\">\r\n                                \r\n
+        \                                   \r\n                                        <li>\r\n
+        \                                           \r\n                                            <a
+        href=\"/online-applications/applicationDetails.do?activeTab=summary&amp;keyVal=_CARDIFF_DCAPR_126451\"
+        id=\"subtab_summary\" class=\"active\">\r\n                                                <span>\r\n
+        \                                                   Summary\r\n                                                    \r\n
+        \                                               </span>\r\n                                            </a>\r\n
+        \                                       </li>\r\n                                    \r\n
+        \                               \r\n                                    \r\n
+        \                                       <li>\r\n                                            \r\n
+        \                                           <a href=\"/online-applications/applicationDetails.do?activeTab=details&amp;keyVal=_CARDIFF_DCAPR_126451\"
+        id=\"subtab_details\">\r\n                                                <span>\r\n
+        \                                                   Further Information\r\n
+        \                                                   \r\n                                                </span>\r\n
+        \                                           </a>\r\n                                        </li>\r\n
+        \                                   \r\n                                \r\n
+        \                                   \r\n                                        <li>\r\n
+        \                                           \r\n                                            <a
+        href=\"/online-applications/applicationDetails.do?activeTab=contacts&amp;keyVal=_CARDIFF_DCAPR_126451\"
+        id=\"subtab_contacts\">\r\n                                                <span>\r\n
+        \                                                   Contacts\r\n                                                    \r\n
+        \                                               </span>\r\n                                            </a>\r\n
+        \                                       </li>\r\n                                    \r\n
+        \                               \r\n                                    \r\n
+        \                                       <li>\r\n                                            \r\n
+        \                                           <a href=\"/online-applications/applicationDetails.do?activeTab=dates&amp;keyVal=_CARDIFF_DCAPR_126451\"
+        id=\"subtab_dates\">\r\n                                                <span>\r\n
+        \                                                   Important Dates\r\n                                                    \r\n
+        \                                               </span>\r\n                                            </a>\r\n
+        \                                       </li>\r\n                                    \r\n
+        \                               \r\n                            </ul>\r\n\r\n
+        \                       \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n                \r\n
+        \               <li>\r\n\r\n                     \r\n                    <a
+        href=\"/online-applications/applicationDetails.do?activeTab=makeComment&amp;keyVal=_CARDIFF_DCAPR_126451\"
+        id=\"tab_makeComment\">\r\n                        <span>\r\n                            Comments\r\n
+        \                           \r\n                                \r\n                                (0)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n\r\n
+        \           \r\n                <li class=\"nodocuments\">\r\n                    <span>\r\n
+        \                       Constraints\r\n                        \r\n                            \r\n
+        \                           (0)\r\n                        \r\n                    </span>\r\n
+        \               </li>\r\n            \r\n\r\n        \r\n\r\n            \r\n
+        \               \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/applicationDetails.do?activeTab=documents&amp;keyVal=_CARDIFF_DCAPR_126451\"
+        id=\"tab_documents\">\r\n                        <span>\r\n                            Documents\r\n
+        \                           \r\n                                \r\n                                (9)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n                \r\n
+        \               <li>\r\n\r\n                     \r\n                    <a
+        href=\"/online-applications/applicationDetails.do?activeTab=relatedCases&amp;keyVal=_CARDIFF_DCAPR_126451\"
+        id=\"tab_relatedCases\">\r\n                        <span>\r\n                            Related
+        Cases\r\n                            \r\n                                \r\n
+        \                               (1)\r\n                            \r\n                        </span>\r\n
+        \                   </a>\r\n\r\n                    \r\n                    \r\n
+        \                   \r\n                </li>\r\n            \r\n\r\n            \r\n\r\n
+        \       \r\n\r\n            \r\n\r\n            \r\n\r\n        \r\n    </ul>\r\n<!--
+        #EndEditable -->\r\n                    <!-- #BeginEditable \"tabsubnav\"
+        --><!-- #EndEditable -->\r\n                    <!-- #BeginEditable \"pagebody\"
+        -->\n    \r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\n
+        \   \n        \n        \n    \n\n    \n    \n    \n    \n    \n\n    <div
+        class=\"tabcontainer\">\n\n        \n        \n        \n\n        \n        \n\n
+        \           \n            \n                \n            \n\n            \n
+        \               <table id=\"simpleDetailsTable\" summary=\"Case Details\">\n\n
+        \                   \n                    \n                        \n                            <tr>\n
+        \                               <th scope=\"row\" width=\"40%\">\n                                    Reference\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            19/00214/DCH\n
+        \                                       \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Alternative Reference\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            PP-07582302\n
+        \                                       \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Application Received\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            Mon
+        04 Feb 2019\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Application Validated\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            Mon
+        11 Feb 2019\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Address\n                                </th>\n
+        \                               <td>\n                                    \n
+        \                                       \n                                        \n
+        \                                           17 PANTGLAS, PENTYRCH, CARDIFF,
+        CF15 9TH\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Proposal\n                                </th>\n
+        \                               <td>\n                                    \n
+        \                                       \n                                        \n
+        \                                           REMOVE EXISTING DECKING AT REAR
+        AND REPLACE WITH GROUND LEVEL AND RAISED PATIOS\n                                        \n
+        \                                   \n                                </td>\n
+        \                           </tr>\n                        \n                    \n
+        \                       \n                            <tr>\n                                <th
+        scope=\"row\" width=\"40%\">\n                                    Status\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                           <span class=\"caseDetailsStatus\">Decided</span>\n
+        \                                       \n                                        \n
+        \                                   \n                                </td>\n
+        \                           </tr>\n                        \n                    \n
+        \                       \n                            <tr>\n                                <th
+        scope=\"row\" width=\"40%\">\n                                    Decision\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            Permission
+        be granted\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Decision Issued Date\n
+        \                               </th>\n                                <td>\n
+        \                                   \n                                        \n
+        \                                       \n                                            Mon
+        08 Apr 2019\n                                        \n                                    \n
+        \                               </td>\n                            </tr>\n
+        \                       \n                    \n                        \n
+        \                           <tr>\n                                <th scope=\"row\"
+        width=\"40%\">\n                                    Appeal Decision\n                                </th>\n
+        \                               <td>\n                                    \n
+        \                                       \n                                        \n
+        \                                           \n                                        \n
+        \                                   \n                                </td>\n
+        \                           </tr>\n                        \n                    \n\n
+        \               </table>\n\n                \n                \n\n                \n\n
+        \           \n\n            \n\n        \n\n        \n        \n            \n
+        \               <div id=\"summaryInfo\">\n                    \n                    \n
+        \                   \n                        \n                            \n
+        \                       \n                    \n\n                    \n                    \n
+        \                       <p class=\"associateddocument\">There are <a href=\"/online-applications/applicationDetails.do?activeTab=documents&amp;keyVal=_CARDIFF_DCAPR_126451\">9
+        documents</a> associated with this application.</p><p class=\"associatedcase\">There
+        are 0 cases associated with this application.</p><p class=\"associatedproperty\">There
+        is <a href=\"/online-applications/applicationDetails.do?activeTab=relatedCases&amp;keyVal=_CARDIFF_DCAPR_126451\">1
+        property</a> associated with this application.</p>\r\n\n                    \n
+        \               </div>\n            \n        \n\n    </div>\n<!-- #EndEditable
+        -->\r\n                    <!-- #BeginEditable \"pagefoot\" --><!-- #EndEditable
+        -->\r\n                </div>\r\n                <!-- END WAM CONTENT -->\r\n
+        \               \r\n                <p id=\"poweredBy\"><a href=\"http://www.idoxgroup.com/\"
+        target=\"_blank\" title=\"This link will open a new window\"><img src=\"/online-applications-skin/images/idox.gif\"
+        alt=\"an Idox solution\" /></a></p>\r\n            </div>\t\r\n\t\t\t<div
+        id=\"footer\">\r\n\t\t\t\t<div class=\"container\">\t\t\t\t\t\r\n\t\t\t\t\t<div
+        id=\"links\">\r\n\t\t\t\t\t\t<ul>\r\n\t\t\t\t\t\t\t<li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Site_Map/Pages/default.aspx\">Site
+        map</a></li><li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Cookies/Pages/Cookies.aspx\">Cookies</a></li><li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/New_Disclaimer/Pages/default.aspx\">Disclaimer</a></li>\r\n\t\t\t\t\t\t</ul>\r\n\t\t\t\t\t</div>\r\n\t\t\t\t\t<div
+        class=\"clear\"></div>\r\n\t\t\t\t</div>\r\n\t\t\t</div>\r\n\t\t\t<div id=\"footerBottom\">\r\n\t\t\t
+        \   <div class=\"container\">\r\n\t\t\t        <div id=\"footercontent\"><p>&copy;
+        <script type=\"text/javascript\">document.write(new Date().getFullYear());</script>
+        Cardiff Council</p></div>\r\n\t\t\t        <div class=\"clear\"></div>\r\n\t\t\t
+        \   </div>\r\n\t\t\t</div>\r\n        </div>    \r\n    </div>  \r\n    <!--
+        IDOX PA END -->           \r\n\t\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Mon, 15 Apr 2019 11:15:40 GMT
+- request:
+    method: get
+    uri: https://planningonline.cardiff.gov.uk/online-applications/applicationDetails.do?activeTab=relatedCases&keyVal=_CARDIFF_DCAPR_126451
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip,deflate,identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mechanize/2.7.6 Ruby/2.6.2p47 (http://github.com/sparklemotion/mechanize/)
+      Accept-Charset:
+      - ISO-8859-1,utf-8;q=0.7,*;q=0.7
+      Accept-Language:
+      - en-us,en;q=0.5
+      Cookie:
+      - JSESSIONID=ss9pKoHL32yHmhJQONSykek96zXCSSZ75skxJ5v1.vmidoxweblve; WSLang-CFC001=EN
+      Host:
+      - planningonline.cardiff.gov.uk
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '300'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - text/html; charset=UTF-8
+      Expires:
+      - Mon, 15 Apr 2019 11:16:12 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ua-Compatible:
+      - IE=edge
+      Server:
+      - Apache
+      Set-Cookie:
+      - WSLang-CFC001=EN; expires=Mon, 15-Apr-2069 11:16:11 GMT; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 15 Apr 2019 11:16:12 GMT
+      Content-Length:
+      - '19977'
+    body:
+      encoding: UTF-8
+      string: "\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n<!DOCTYPE
+        html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\r\n<html
+        lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\r\n<head>\r\n\t\r\n\t<!--
+        #BeginEditable \"doctitle\" -->\r\n    <title>\r\n    19/00214/DCH\r\n    |\r\n
+        \   \r\n        REMOVE EXISTING DECKING AT REAR AND REPLACE WITH GROUND LEVEL
+        AND RAISED PATIOS\r\n        \r\n        |\r\n        \r\n    \r\n\r\n    \r\n\r\n
+        \   \r\n\r\n    \r\n    \r\n    \r\n    \r\n    \r\n        \r\n        17
+        PANTGLAS, PENTYRCH, CARDIFF, CF15 9TH\r\n    \r\n    \r\n    </title>\r\n<!--
+        #EndEditable -->\r\n    <!-- #BeginEditable \"metatags\" --><!-- #EndEditable
+        -->\r\n\t\r\n    <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
+        />\r\n\t\r\n\t<!-- Customer metatags -->\r\n\t\r\n\t\r\n\t<!-- Favicon link
+        -->\r\n    <link rel=\"icon\" href=\"/online-applications-skin/images/cardiff/favicon.ico\"
+        type=\"image/x-icon\" />\r\n\t\r\n    <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/screen.css\"
+        type=\"text/css\" media=\"screen,projection\" />\r\n    <link rel=\"stylesheet\"
+        href=\"/online-applications-skin/styles/theme1.css\" type=\"text/css\"/>    \r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/print.css\"
+        type=\"text/css\" media=\"print\" />\r\n\t\r\n    <script type=\"text/javascript\"
+        src=\"/online-applications-skin/scripts/jquery.min.js\"></script>\r\n    <script
+        type=\"text/javascript\" src=\"/online-applications-skin/scripts/jquery.toolbar.idox.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/common.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/checkbox.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/amplify.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/createCommentCookie.js\"></script>\r\n
+        \       \r\n\t<!-- Customer Analytics Script -->\r\n\t\r\n\t\r\n    <script
+        type=\"text/javascript\">\r\n    \t$('html').addClass('js');\r\n    \t$(document).ready(function(){\r\n
+        \   \t\t$('.main#apply>span:first-child').attr('tabindex', '0')\r\n    \t});\r\n
+        \   </script>\r\n    \r\n    <!-- #BeginEditable \"mobile\" --><!-- #EndEditable
+        -->\r\n    <!-- #BeginEditable \"head\" --><!-- #EndEditable -->\r\n    <!--
+        #BeginEditable \"webapp\" -->\r\n\t<script type=\"text/javascript\">\r\n\t
+        \   jQuery(document).ready(function() {\t\t\r\n\t\t\tjQuery('#pa').before('<img
+        src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\" id=\"preload\"
+        />');\r\n\t\t\tjQuery('#preload').hide();\r\n\t\t\tjQuery('.tabs a#tab_documents').click(
+        function(event) {\r\n\t\t\t\t  window.clearTimeout(window.timeOutId);\r\n\t\t\t\t
+        \ window.timeOutId = window.setTimeout(function() {\r\n\t\t\t\t\t\tjQuery('.content').before('<div
+        id=\"overlay\"></div><div id=\"loading\"><div id=\"message\">Loading. Please
+        wait.... <img src=\"/online-applications-skin/images/ajax-loader.gif\" alt=\"Loading\"
+        height=\"19\" width=\"220\" style=\"background:#fff;\" /></div></div>');\r\n\t\t\t\t
+        \ },10); \r\n\t\t\t\t});\r\n\t\t\t\t\r\n\t\t});\r\n\t</script>\r\n            \r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/simple_social_share.min.css\"
+        type=\"text/css\"/>\r\n    <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/simple_social_share.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\">\r\n        $(document).ready(function(){\r\n
+        \           \r\n            \r\n            $(\"share-button\").simpleSocialShare({\r\n
+        \               sites: \"twitter,email\", \r\n                url: window.location.href,
+        \r\n                title: \"Online application\", \r\n                description:
+        \"Please look at this Planning Application: \", \r\n                shareType:
+        \"button\", \r\n                buttonSide: \"left\", \r\n                orientation:
+        \"horizontal\"\r\n            });\r\n        });\r\n\t</script>\r\n\t<!--
+        #EndEditable -->\r\n\r\n</head>\r\n<body>\r\n\r\n    <a href=\"#pageheading\"
+        class=\"sr-only\">Skip to main content</a>\r\n\r\n    <!-- IDOX PA START -->\r\n
+        \   <div id=\"idox\">\r\n        <div id=\"pa\">\r\n\t\t\t<div id=\"header\"><!--
+        Selector: Selector 1 -->\r\n<style>\r\n#langStyle{float:right; margin-top:
+        10px; margin-right: 30px; background:transparent; font-size:13px; cursor:pointer;
+        border:1px solid #fff !important;border-radius:2px; z-index:999; background-color:
+        #fff; padding:2px;}\r\n#langStyle:hover{text-decoration: underline;}</style>\r\n<div>\r\n\r\n<!--CYS--><a
+        id=\"langStyle\" href=\"/online-applications/applicationDetails.do?activeTab=relatedCases&keyVal=_CARDIFF_DCAPR_126451&lang=CY\">Cymraeg</a><!--CYE-->\r\n</div>\r\n\t\t\t\t<div
+        class=\"container\">\r\n\t\t\t\t\t<div id=\"logo\"><a href=\"https://www.cardiff.gov.uk/\"
+        title=\"Cardiff Council home page\"><img src=\"/online-applications-skin/images/cardiff/logo.png\"
+        alt=\"Council logo\" /><span class=\"sr-only\">Cardiff Council</span></a></div>\r\n\t\t\t\t\t<div
+        id=\"headertitle\"><span></span></div>\r\n\t\t\t\t\t<div class=\"clear\"></div>\r\n\t\t\t\t</div>\t\r\n\t\t\t</div>\r\n\t\t\t<div
+        id=\"breadcrumbs\" class=\"container\">\r\n\t\t\t\t<ul>\r\n\t\t\t\t\t\r\n\t\t\t\t</ul>\r\n\t\t\t</div>\r\n
+        \           <div class=\"container\">\r\n       \t\t\t<div id=\"toolbar\"
+        class=\"nojs\">\r\n                    <ul>\t\r\n                        <li
+        id=\"search\" class=\"main\"><span tabindex=\"0\">Search&nbsp;</span><span
+        class=\"caret\"></span>\r\n   \t\t\t\t\t\t\t<ul>\t\r\n\t\t\t\t\t\t\t\t<!--
+        #BeginLibraryItem \"/Library/searchModulesNavItems.lbi\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \       \r\n            <li id=\"planLinks\">\r\n                <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\"
+        >\r\n                    <span>Planning</span>\r\n                </a>\r\n
+        \               <ul>\r\n                    <li id=\"planBasicSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\">\r\n
+        \                           Simple Search\r\n                        </a>\r\n
+        \                   </li>\r\n\r\n                    <li id=\"planAdvancedSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=advanced&amp;searchType=Application\">\r\n
+        \                           Advanced\r\n                        </a>\r\n                    </li>\r\n
+        \                   <li id=\"planListSearch\">\r\n                        <a
+        href=\"/online-applications/search.do?action=weeklyList&amp;searchType=Application\">\r\n
+        \                           Weekly/Monthly Lists\r\n                        </a>\r\n
+        \                   </li>\r\n                    <li id=\"planPropertySearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=property&amp;type=custom\">\r\n
+        \                           Property Search\r\n                        </a>\r\n
+        \                   </li>\r\n\t\t\t\t\t\r\n                    \r\n\t\t\t\t\t\r\n
+        \               </ul>\r\n            </li>\r\n        \r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        <!-- #EndLibraryItem -->\r\n                        \t</ul>\r\n\t\t\t\t\t\t</li>\r\n
+        \                       <!-- #BeginEditable \"applicationForms\" -->\n\n\n\n\n\n
+        \  \n<!-- #EndEditable -->   \t\t\t\t\r\n                        <li id=\"myprofile\"
+        class=\"main\"><span tabindex=\"0\">My Profile&nbsp;</span><span class=\"caret\"></span>\r\n
+        \                           <ul>\r\n                              <!-- #BeginLibraryItem
+        \"/Library/consulteeInTrayNavItem.lbi\" -->\n\n\n\n\n\n\n    <!-- #EndLibraryItem
+        -->\r\n                                <li><a href=\"/online-applications/registered/displayUserDetails.do\">Profile
+        Details</a></li>\r\n                                <li><a href=\"/online-applications/registered/savedSearch.do?action=display\">Saved
+        Searches</a></li>\r\n                                <li><a href=\"/online-applications/registered/userAdmin.do?action=showNotifiedApplications\">Notified
+        Applications</a></li>\r\n                                <li><a href=\"/online-applications/registered/trackedApplication.do?action=display\">Tracked
+        Applications</a></li>\r\n                                <!-- #BeginEditable
+        \"formSubmissions\" -->\n\n\n\n\n\n\n\n\n<!-- #EndEditable -->    \t\r\n                            </ul>\r\n
+        \                       </li>\r\n                        <li id=\"loginLink\"
+        class=\"main\"><!-- #BeginEditable \"loginlogout\" -->\n\n\n\n\n\n\n\n\n\n\n\t<a
+        href=\"/online-applications/registered/userAdmin.do\">Login</a>\n<!-- #EndEditable
+        --></li>\r\n                        <!-- #BeginEditable \"register\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \  \r\n\r\n\r\n\t<li id=\"register\">\r\n        <a href=\"/online-applications/registrationWizard.do?action=start\">Register</a>\r\n\t</li>\r\n\r\n<!--
+        #EndEditable -->\r\n                        <!-- #BeginLibraryItem \"/Library/applyOnlineNavItems.lbi\"
+        -->\r\n\r\n\r\n\r\n\r\n\r\n<!-- #EndLibraryItem -->\r\n                    </ul>\r\n
+        \   \t\t\t</div>\r\n\r\n    \t\t\t<!-- #BeginEditable \"headlinenews\" --><!--
+        #EndEditable -->\r\n                 \r\n                <div id=\"pageheading\">\r\n
+        \                   <h1><strong>Planning</strong>&nbsp;&ndash;&nbsp;<!-- #BeginEditable
+        \"pageheading\" -->Application Related Items<!-- #EndEditable --></h1>\r\n
+        \                   <!-- #BeginEditable \"helplink\" -->\r\n<p class=\"pagehelp\">\r\n\t<a
+        title=\"Help with this page (opens in a new window)\" rel=\"external\" target=\"_blank\"
+        href=\"/online-applications/help/pagehelp/applications.htm\">\r\n\t\tHelp
+        with this page\r\n\t<span> (opens in a new window)</span>\r\n\t</a>\r\n</p>\r\n<!--
+        #EndEditable -->\r\n                </div>\r\n                \r\n                <!--
+        START WAM CONTENT -->\r\n                <div class=\"content\">\r\n                    <!--
+        #BeginEditable \"errormsg\" --><!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"pagehead\" -->\r\n\r\n    <div class=\"addressCrumb\">\r\n
+        \       <span class=\"caseNumber\">\r\n            \r\n\r\n            \r\n
+        \               19/00214/DCH\r\n            \r\n        </span>\r\n\r\n        <span
+        class=\"divider1\">|</span>\r\n\r\n        \r\n            <span class=\"description\">\r\n
+        \               REMOVE EXISTING DECKING AT REAR AND REPLACE WITH GROUND LEVEL
+        AND RAISED PATIOS\r\n            </span>\r\n            \r\n                <span
+        class=\"divider2\">|</span>\r\n            \r\n        \r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        \r\n        \r\n        \r\n        \r\n        \r\n
+        \           \r\n            <span class=\"address\">\r\n                17
+        PANTGLAS, PENTYRCH, CARDIFF, CF15 9TH\r\n            </span>\r\n        \r\n
+        \       \r\n    </div>\r\n\r\n\r\n    <div id=\"applicationTools\">\r\n        <ul>\r\n
+        \           \r\n            \r\n                \r\n                    \r\n
+        \                       \r\n                            \r\n                            \r\n
+        \                               \r\n                                    <li>\r\n
+        \                                       <a href=\"/online-applications/searchResultsBack.do?action=back\"
+        id=\"searchresultsback\">Back to search results</a>\r\n                                    </li>\r\n
+        \                               \r\n                            \r\n                        \r\n
+        \                   \r\n                    \r\n                    \r\n                \r\n
+        \           \r\n\r\n            \r\n\r\n            \r\n            \r\n\r\n
+        \           \r\n\r\n            \r\n            \r\n                \r\n                    <li>\r\n
+        \                       <form name=\"trackForm\" method=\"post\" action=\"/online-applications/registered/trackedApplicationSubmit.do?action=track\"><input
+        type=\"hidden\" name=\"org.apache.struts.taglib.html.TOKEN\" value=\"a3a9cd286e4e2ea2199148de99ea4f70\"
+        />\r\n                            <input type=\"hidden\" name=\"caseNo\" value=\"19/00214/DCH\"
+        />\r\n                            <input type=\"hidden\" name=\"caseType\"
+        value=\"Application\" />\r\n                            <input type=\"hidden\"
+        name=\"address\" value=\"17 PANTGLAS, PENTYRCH, CARDIFF, CF15 9TH\" />\r\n
+        \                           <input type=\"hidden\" name=\"description\" value=\"REMOVE
+        EXISTING DECKING AT REAR AND REPLACE WITH GROUND LEVEL AND RAISED PATIOS\"
+        />\r\n                            <input type=\"hidden\" name=\"status\" value=\"Decided\"
+        />\r\n                            <input type=\"hidden\" name=\"trackingStatus\"
+        value=\"Decided\" />\r\n                            <input type=\"hidden\"
+        name=\"caseTechnicalKey\" value=\"_CARDIFF_DCAPR_126451\" />\r\n                            <input
+        class=\"casefiletrack\"\r\n                                   src=\"/online-applications-skin/images/button_track.gif\"\r\n
+        \                                  type=\"image\"\r\n                                   name=\"submit\"\r\n
+        \                                  altKey=\"casedetails.track\"\r\n                                   title=\"Get
+        informed when this item is updated\"/>\r\n                        </form>\r\n
+        \                   </li>\r\n                \r\n\r\n                \r\n
+        \           \r\n\r\n\r\n            \r\n                \r\n             \r\n
+        \           \r\n\r\n            \r\n            \r\n                \r\n            \r\n
+        \           \r\n            \r\n            <li>\r\n                <a href=\"/online-applications/applicationDetails.do?activeTab=printPreview&amp;keyVal=_CARDIFF_DCAPR_126451\"
+        id=\"print\" rel=\"external\">\r\n                    <img src=\"/online-applications-skin/images/button_print.gif\"
+        alt=\"Print summary icon\" width=\"53\" height=\"22\" border=\"0\"/>\r\n                </a>\r\n
+        \           </li>\r\n            \r\n\r\n            \r\n        </ul>\r\n\r\n
+        \   </div>\r\n\r\n\r\n     \r\n\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabs\" -->\r\n    \r\n    <ul class=\"tabs\">\r\n\r\n        \r\n\r\n
+        \           \r\n                \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/applicationDetails.do?activeTab=summary&amp;keyVal=_CARDIFF_DCAPR_126451\"
+        id=\"tab_summary\">\r\n                        <span>\r\n                            Details\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n                \r\n
+        \               <li>\r\n\r\n                     \r\n                    <a
+        href=\"/online-applications/applicationDetails.do?activeTab=makeComment&amp;keyVal=_CARDIFF_DCAPR_126451\"
+        id=\"tab_makeComment\">\r\n                        <span>\r\n                            Comments\r\n
+        \                           \r\n                                \r\n                                (0)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n\r\n
+        \           \r\n                <li class=\"nodocuments\">\r\n                    <span>\r\n
+        \                       Constraints\r\n                        \r\n                            \r\n
+        \                           (0)\r\n                        \r\n                    </span>\r\n
+        \               </li>\r\n            \r\n\r\n        \r\n\r\n            \r\n
+        \               \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/applicationDetails.do?activeTab=documents&amp;keyVal=_CARDIFF_DCAPR_126451\"
+        id=\"tab_documents\">\r\n                        <span>\r\n                            Documents\r\n
+        \                           \r\n                                \r\n                                (9)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n                \r\n
+        \               <li>\r\n\r\n                     \r\n                    <a
+        href=\"/online-applications/applicationDetails.do?activeTab=relatedCases&amp;keyVal=_CARDIFF_DCAPR_126451\"
+        id=\"tab_relatedCases\" class=\"active\">\r\n                        <span>\r\n
+        \                           Related Cases\r\n                            \r\n
+        \                               \r\n                                (1)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                        \r\n
+        \                       \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n\r\n
+        \           \r\n\r\n        \r\n    </ul>\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabsubnav\" --><!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"pagebody\" -->\r\n\r\n    \r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \   <div class=\"tabcontainer toplevel\">\r\n    <div id=\"relatedItems\">\r\n\r\n
+        \       \r\n            \r\n            \r\n\r\n            <!-- Display header
+        -->\r\n            <div id=\"Application\">\r\n                <h3>\r\n                    \r\n
+        \                   \r\n                        Planning Applications\r\n
+        \                   \r\n                    <span>(0)</span>\r\n                </h3>\n\r\n\r\n
+        \               <!-- Display each item -->\r\n                \r\n            </div>\r\n\r\n
+        \       \r\n            \r\n            \r\n\r\n            <!-- Display header
+        -->\r\n            <div id=\"Appeal\">\r\n                <h3>\r\n                    \r\n
+        \                   \r\n                        Planning Appeals\r\n                    \r\n
+        \                   <span>(0)</span>\r\n                </h3>\n\r\n\r\n                <!--
+        Display each item -->\r\n                \r\n            </div>\r\n\r\n        \r\n
+        \           \r\n            \r\n\r\n            <!-- Display header -->\r\n
+        \           <div id=\"Enforcement\">\r\n                <h3>\r\n                    \r\n
+        \                   \r\n                        Planning Enforcements\r\n
+        \                   \r\n                    <span>(0)</span>\r\n                </h3>\n\r\n\r\n
+        \               <!-- Display each item -->\r\n                \r\n            </div>\r\n\r\n
+        \       \r\n            \r\n            \r\n\r\n            <!-- Display header
+        -->\r\n            <div id=\"Property\">\r\n                <h3>\r\n                    \r\n
+        \                   \r\n                        Properties\r\n                    \r\n
+        \                   <span>(1)</span>\r\n                </h3>\n\r\n\r\n                <!--
+        Display each item -->\r\n                \r\n                    <ul>\r\n
+        \                       \r\n                            <li>\r\n                                \r\n
+        \                               \r\n                                \r\n\r\n
+        \                               <a href=\"/online-applications/propertyDetails.do?previousCaseType=Application&amp;keyVal=_CARDIFF_PROPLPI_20269_1&amp;previousCaseNumber=19%2F00214%2FDCH&amp;activeTab=summary&amp;previousKeyVal=_CARDIFF_DCAPR_126451\">\r\n
+        \                                   17 PANTGLAS, PENTYRCH, CARDIFF, CF15 9TH\r\n
+        \                               </a>\r\n\r\n                                <p
+        class=\"metaInfo\">\r\n\r\n                                \r\n\r\n                                \r\n\r\n
+        \                               \r\n                                \r\n                                \r\n
+        \                              </p>\r\n                            </li>\r\n
+        \                       \r\n                    </ul>\r\n                \r\n
+        \           </div>\r\n\r\n        \r\n\r\n    </div>\r\n    </div>\r\n\r\n<!--
+        #EndEditable -->\r\n                    <!-- #BeginEditable \"pagefoot\" --><!--
+        #EndEditable -->\r\n                </div>\r\n                <!-- END WAM
+        CONTENT -->\r\n                \r\n                <p id=\"poweredBy\"><a
+        href=\"http://www.idoxgroup.com/\" target=\"_blank\" title=\"This link will
+        open a new window\"><img src=\"/online-applications-skin/images/idox.gif\"
+        alt=\"an Idox solution\" /></a></p>\r\n            </div>\t\r\n\t\t\t<div
+        id=\"footer\">\r\n\t\t\t\t<div class=\"container\">\t\t\t\t\t\r\n\t\t\t\t\t<div
+        id=\"links\">\r\n\t\t\t\t\t\t<ul>\r\n\t\t\t\t\t\t\t<li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Site_Map/Pages/default.aspx\">Site
+        map</a></li><li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Cookies/Pages/Cookies.aspx\">Cookies</a></li><li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/New_Disclaimer/Pages/default.aspx\">Disclaimer</a></li>\r\n\t\t\t\t\t\t</ul>\r\n\t\t\t\t\t</div>\r\n\t\t\t\t\t<div
+        class=\"clear\"></div>\r\n\t\t\t\t</div>\r\n\t\t\t</div>\r\n\t\t\t<div id=\"footerBottom\">\r\n\t\t\t
+        \   <div class=\"container\">\r\n\t\t\t        <div id=\"footercontent\"><p>&copy;
+        <script type=\"text/javascript\">document.write(new Date().getFullYear());</script>
+        Cardiff Council</p></div>\r\n\t\t\t        <div class=\"clear\"></div>\r\n\t\t\t
+        \   </div>\r\n\t\t\t</div>\r\n        </div>    \r\n    </div>  \r\n    <!--
+        IDOX PA END -->           \r\n\t\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Mon, 15 Apr 2019 11:15:41 GMT
+- request:
+    method: get
+    uri: https://planningonline.cardiff.gov.uk/online-applications/propertyDetails.do?activeTab=summary&keyVal=_CARDIFF_PROPLPI_20269_1&previousCaseNumber=19/00214/DCH&previousCaseType=Application&previousKeyVal=_CARDIFF_DCAPR_126451
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip,deflate,identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mechanize/2.7.6 Ruby/2.6.2p47 (http://github.com/sparklemotion/mechanize/)
+      Accept-Charset:
+      - ISO-8859-1,utf-8;q=0.7,*;q=0.7
+      Accept-Language:
+      - en-us,en;q=0.5
+      Cookie:
+      - JSESSIONID=ss9pKoHL32yHmhJQONSykek96zXCSSZ75skxJ5v1.vmidoxweblve; WSLang-CFC001=EN
+      Host:
+      - planningonline.cardiff.gov.uk
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '300'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - text/html; charset=UTF-8
+      Expires:
+      - Mon, 15 Apr 2019 11:16:14 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ua-Compatible:
+      - IE=edge
+      Server:
+      - Apache
+      Set-Cookie:
+      - WSLang-CFC001=EN; expires=Mon, 15-Apr-2069 11:16:13 GMT; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 15 Apr 2019 11:16:14 GMT
+      Content-Length:
+      - '13484'
+    body:
+      encoding: UTF-8
+      string: "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n    \n\n    \n\n<!DOCTYPE html PUBLIC
+        \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\r\n<html
+        lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\r\n<head>\r\n\r\n\t<!--
+        #BeginEditable \"doctitle\" -->\r\n    <title>\r\n    _CARDIFF_PROPLPI_20269_1\r\n
+        \   |\r\n    \r\n\r\n    \r\n\r\n    \r\n\r\n    \r\n    \r\n    \r\n    \r\n
+        \   \r\n        \r\n        17 PANTGLAS, PENTYRCH, CARDIFF, CF15 9TH\r\n    \r\n
+        \   \r\n    </title>\r\n<!-- #EndEditable -->\r\n    <!-- #BeginEditable \"metatags\"
+        --><!-- #EndEditable -->\r\n\t\r\n    <meta http-equiv=\"Content-Type\" content=\"text/html;
+        charset=UTF-8\" />\r\n\t\r\n\t<!-- Customer metatags -->\r\n\t\r\n\t\r\n\t<!--
+        Favicon link -->\r\n    <link rel=\"icon\" href=\"/online-applications-skin/images/cardiff/favicon.ico\"
+        type=\"image/x-icon\" />\r\n\t\r\n    <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/screen.css\"
+        type=\"text/css\" media=\"screen,projection\" />\r\n    <link rel=\"stylesheet\"
+        href=\"/online-applications-skin/styles/theme1.css\" type=\"text/css\"/>\t\r\n
+        \   <link rel=\"stylesheet\" href=\"/online-applications-skin/styles/print.css\"
+        type=\"text/css\" media=\"print\" />   \r\n\r\n    <script type=\"text/javascript\"
+        src=\"/online-applications-skin/scripts/jquery.min.js\"></script>\r\n    <script
+        type=\"text/javascript\" src=\"/online-applications-skin/scripts/jquery.toolbar.idox.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/online-applications-skin/scripts/common.js\"></script>\r\n
+        \       \r\n\t<!-- Customer Analytics Script -->\r\n\t\r\n\t\r\n    <script
+        type=\"text/javascript\">\r\n    \t$('html').addClass('js');\r\n    \t$(document).ready(function(){\r\n
+        \   \t\t$('.main#apply>span:first-child').attr('tabindex', '0')\r\n    \t});\r\n
+        \   </script>\r\n    \r\n    <!-- #BeginEditable \"mobile\" --><!-- #EndEditable
+        -->\r\n    <!-- #BeginEditable \"head\" --><!-- #EndEditable -->\r\n    <!--
+        #BeginEditable \"webapp\" --><!-- #EndEditable -->\r\n\r\n</head>\r\n<body>\r\n\r\n
+        \   <a href=\"#pageheading\" class=\"sr-only\">Skip to main content</a>\r\n\r\n
+        \   <!-- IDOX PA START -->\r\n    <div id=\"idox\">\r\n        <div id=\"pa\">
+        \r\n\t\t\t<div id=\"header\"><!-- Selector: Selector 1 -->\r\n<style>\r\n#langStyle{float:right;
+        margin-top: 10px; margin-right: 30px; background:transparent; font-size:13px;
+        cursor:pointer; border:1px solid #fff !important;border-radius:2px; z-index:999;
+        background-color: #fff; padding:2px;}\r\n#langStyle:hover{text-decoration:
+        underline;}</style>\r\n<div>\r\n\r\n<!--CYS--><a id=\"langStyle\" href=\"/online-applications/propertyDetails.do?previousCaseType=Application&keyVal=_CARDIFF_PROPLPI_20269_1&previousCaseNumber=19%2f00214%2fDCH&activeTab=summary&previousKeyVal=_CARDIFF_DCAPR_126451&lang=CY\">Cymraeg</a><!--CYE-->\r\n</div>\r\n\t\t\t\t<div
+        class=\"container\">\r\n\t\t\t\t\t<div id=\"logo\"><a href=\"https://www.cardiff.gov.uk/\"
+        title=\"Cardiff Council home page\"><img src=\"/online-applications-skin/images/cardiff/logo.png\"
+        alt=\"Council logo\" /><span class=\"sr-only\">Cardiff Council</span></a></div>\r\n\t\t\t\t\t<div
+        id=\"headertitle\"><span></span></div>\r\n\t\t\t\t\t<div class=\"clear\"></div>\r\n\t\t\t\t</div>\t\r\n\t\t\t</div>\r\n\t\t\t<div
+        id=\"breadcrumbs\" class=\"container\">\r\n\t\t\t\t<ul>\r\n\t\t\t\t\t\r\n\t\t\t\t</ul>\r\n\t\t\t</div>\r\n
+        \           <div class=\"container\">\r\n                <div id=\"toolbar\"
+        class=\"nojs\">\r\n                    <ul>\t\r\n                        <li
+        id=\"search\" class=\"main\"><span tabindex=\"0\">Search&nbsp;</span><span
+        class=\"caret\"></span>\r\n   \t\t\t\t\t\t\t<ul>\t\r\n\t\t\t\t\t\t\t\t<!--
+        #BeginLibraryItem \"/Library/searchModulesNavItems.lbi\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \       \r\n            <li id=\"planLinks\">\r\n                <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\"
+        >\r\n                    <span>Planning</span>\r\n                </a>\r\n
+        \               <ul>\r\n                    <li id=\"planBasicSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=simple&amp;searchType=Application\">\r\n
+        \                           Simple Search\r\n                        </a>\r\n
+        \                   </li>\r\n\r\n                    <li id=\"planAdvancedSearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=advanced&amp;searchType=Application\">\r\n
+        \                           Advanced\r\n                        </a>\r\n                    </li>\r\n
+        \                   <li id=\"planListSearch\">\r\n                        <a
+        href=\"/online-applications/search.do?action=weeklyList&amp;searchType=Application\">\r\n
+        \                           Weekly/Monthly Lists\r\n                        </a>\r\n
+        \                   </li>\r\n                    <li id=\"planPropertySearch\">\r\n
+        \                       <a href=\"/online-applications/search.do?action=property&amp;type=custom\">\r\n
+        \                           Property Search\r\n                        </a>\r\n
+        \                   </li>\r\n\t\t\t\t\t\r\n                    \r\n\t\t\t\t\t\r\n
+        \               </ul>\r\n            </li>\r\n        \r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        <!-- #EndLibraryItem -->\r\n                        \t</ul>\r\n\t\t\t\t\t\t</li>\r\n
+        \                       <!-- #BeginEditable \"applicationForms\" -->\n\n\n\n\n\n
+        \  \n<!-- #EndEditable -->   \t\t\t\t\r\n                        <li id=\"myprofile\"
+        class=\"main\"><span tabindex=\"0\">My Profile&nbsp;</span><span class=\"caret\"></span>\r\n
+        \                           <ul>\r\n                              <!-- #BeginLibraryItem
+        \"/Library/consulteeInTrayNavItem.lbi\" -->\n\n\n\n\n\n\n    <!-- #EndLibraryItem
+        -->\r\n                                <li><a href=\"/online-applications/registered/displayUserDetails.do\">Profile
+        Details</a></li>\r\n                                <li><a href=\"/online-applications/registered/savedSearch.do?action=display\">Saved
+        Searches</a></li>\r\n                                <li><a href=\"/online-applications/registered/userAdmin.do?action=showNotifiedApplications\">Notified
+        Applications</a></li>\r\n                                <li><a href=\"/online-applications/registered/trackedApplication.do?action=display\">Tracked
+        Applications</a></li>\r\n                                <!-- #BeginEditable
+        \"formSubmissions\" -->\n\n\n\n\n\n\n\n\n<!-- #EndEditable -->    \t\r\n                            </ul>\r\n
+        \                       </li>\r\n                        <li id=\"loginLink\"
+        class=\"main\"><!-- #BeginEditable \"loginlogout\" -->\n\n\n\n\n\n\n\n\n\n\n\t<a
+        href=\"/online-applications/registered/userAdmin.do\">Login</a>\n<!-- #EndEditable
+        --></li>\r\n                        <!-- #BeginEditable \"register\" -->\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n
+        \  \r\n\r\n\r\n\t<li id=\"register\">\r\n        <a href=\"/online-applications/registrationWizard.do?action=start\">Register</a>\r\n\t</li>\r\n\r\n<!--
+        #EndEditable -->\r\n                        <!-- #BeginLibraryItem \"/Library/applyOnlineNavItems.lbi\"
+        -->\r\n\r\n\r\n\r\n\r\n\r\n<!-- #EndLibraryItem -->\r\n                    </ul>\r\n
+        \   \t\t\t</div>\r\n                \r\n                <div id=\"pageheading\">\r\n
+        \                   <h1><!-- #BeginEditable \"pageheading\" -->Property Address<!--
+        #EndEditable --></h1>\r\n                    <!-- #BeginEditable \"helplink\"
+        -->\r\n<p class=\"pagehelp\">\r\n\t<a title=\"Help with this page (opens in
+        a new window)\" rel=\"external\" target=\"_blank\" href=\"/online-applications/help/pagehelp/properties.htm\">\r\n\t\tHelp
+        with this page\r\n\t<span> (opens in a new window)</span>\r\n\t</a>\r\n</p>\r\n<!--
+        #EndEditable -->\r\n                </div>\r\n        \r\n                <!--
+        START WAM CONTENT -->\r\n                <div class=\"content\">\r\n                    <!--
+        #BeginEditable \"errormsg\" -->\n        \n        \n\n        \n        \n
+        \   <!-- #EndEditable -->\r\n                    <!-- #BeginEditable \"pagehead\"
+        -->\r\n\r\n    <div class=\"addressCrumb\">\r\n        <span class=\"caseNumber\">\r\n
+        \           \r\n                100100140556 \r\n            \r\n\r\n            \r\n
+        \       </span>\r\n\r\n        <span class=\"divider1\">|</span>\r\n\r\n        \r\n\r\n
+        \       \r\n\r\n        \r\n\r\n        \r\n        \r\n        \r\n        \r\n
+        \       \r\n            \r\n            <span class=\"address\">\r\n                17
+        PANTGLAS, PENTYRCH, CARDIFF, CF15 9TH\r\n            </span>\r\n        \r\n
+        \       \r\n    </div>\r\n\r\n\r\n    <div id=\"applicationTools\">\r\n        <ul>\r\n
+        \           \r\n            \r\n\r\n            \r\n\r\n            \r\n            \r\n
+        \               <li>\r\n                    <a href=\"/online-applications/applicationDetails.do?keyVal=_CARDIFF_DCAPR_126451&amp;activeTab=summary\"
+        id=\"searchresultsback\">\r\n                        Planning Application\r\n
+        \                       \r\n                        \r\n                            19/00214/DCH\r\n
+        \                       \r\n                    </a>\r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n            \r\n            \r\n\r\n\r\n
+        \           \r\n                \r\n             \r\n            \r\n\r\n
+        \           \r\n            \r\n                \r\n            \r\n            \r\n
+        \           \r\n            <li>\r\n                <a href=\"/online-applications/propertyDetails.do?activeTab=printPreview&amp;keyVal=_CARDIFF_PROPLPI_20269_1\"
+        id=\"print\" rel=\"external\">\r\n                    <img src=\"/online-applications-skin/images/button_print.gif\"
+        alt=\"Print summary icon\" width=\"53\" height=\"22\" border=\"0\"/>\r\n                </a>\r\n
+        \           </li>\r\n            \r\n\r\n            \r\n        </ul>\r\n\r\n
+        \   </div>\r\n\r\n\r\n     \r\n\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabs\" -->\r\n    \r\n    <ul class=\"tabs\">\r\n\r\n        \r\n\r\n
+        \           \r\n                \r\n                <li>\r\n\r\n                     \r\n
+        \                   <a href=\"/online-applications/propertyDetails.do?activeTab=summary&amp;keyVal=_CARDIFF_PROPLPI_20269_1\"
+        id=\"tab_summary\" class=\"active\">\r\n                        <span>\r\n
+        \                           Address\r\n                            \r\n                        </span>\r\n
+        \                   </a>\r\n\r\n                    \r\n                    \r\n
+        \                   \r\n                        \r\n                        \r\n
+        \                   \r\n                </li>\r\n            \r\n\r\n            \r\n\r\n
+        \       \r\n\r\n            \r\n                \r\n                <li>\r\n\r\n
+        \                    \r\n                    <a href=\"/online-applications/propertyDetails.do?activeTab=relatedCases&amp;keyVal=_CARDIFF_PROPLPI_20269_1\"
+        id=\"tab_relatedCases\">\r\n                        <span>\r\n                            Property
+        History\r\n                            \r\n                                \r\n
+        \                               (2)\r\n                            \r\n                        </span>\r\n
+        \                   </a>\r\n\r\n                    \r\n                    \r\n
+        \                   \r\n                </li>\r\n            \r\n\r\n            \r\n\r\n
+        \       \r\n\r\n            \r\n                \r\n                <li>\r\n\r\n
+        \                    \r\n                    <a href=\"/online-applications/propertyDetails.do?activeTab=constraints&amp;keyVal=_CARDIFF_PROPLPI_20269_1\"
+        id=\"tab_constraints\">\r\n                        <span>\r\n                            Constraints\r\n
+        \                           \r\n                                \r\n                                (1)\r\n
+        \                           \r\n                        </span>\r\n                    </a>\r\n\r\n
+        \                   \r\n                    \r\n                    \r\n                </li>\r\n
+        \           \r\n\r\n            \r\n\r\n        \r\n\r\n            \r\n\r\n
+        \           \r\n\r\n        \r\n    </ul>\r\n<!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"tabsubnav\" --><!-- #EndEditable -->\r\n                    <!--
+        #BeginEditable \"pagebody\" -->\n    \r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\n
+        \   \n        \n        \n    \n\n    \n    \n    \n    \n    \n        \n
+        \       \n    \n\n    <div class=\"tabcontainer toplevel\">\n\n        \n
+        \       \n        \n            \n            <table id=\"propertyAddress\"
+        summary=\"Property address\">\r\n<tr class=\"row0\">\r\n<th scope=\"row\">UPRN:</th>\r\n<td>100100140556</td>\r\n</tr>\r\n<tr
+        class=\"row1\">\r\n<th scope=\"row\">Full Address:</th>\r\n<td>17 PANTGLAS,
+        PENTYRCH, CARDIFF, CF15 9TH</td>\r\n</tr>\r\n<tr class=\"row1\">\r\n<th scope=\"row\">Property
+        Number:</th>\r\n<td>17</td>\r\n</tr>\r\n<tr class=\"row0\">\r\n<th scope=\"row\">Street:</th>\r\n<td>PANTGLAS</td>\r\n</tr>\r\n<tr
+        class=\"row1\">\r\n<th scope=\"row\">Town:</th>\r\n<td>CARDIFF</td>\r\n</tr>\r\n<tr
+        class=\"row0\">\r\n<th scope=\"row\">Postcode:</th>\r\n<td>CF15 9TH</td>\r\n</tr>\r\n<tr
+        class=\"row1\">\r\n<th scope=\"row\">Ward:</th>\r\n<td>PENTYRCH</td>\r\n</tr>\r\n<tr
+        class=\"row0\">\r\n<th scope=\"row\">Parish:</th>\r\n<td/>\r\n</tr>\r\n</table>\r\n\n
+        \       \n\n        \n        \n\n        \n        \n            \n        \n\n
+        \   </div>\n<!-- #EndEditable -->\r\n                    <!-- #BeginEditable
+        \"pagefoot\" --><!-- #EndEditable -->\r\n                </div>\r\n                <!--
+        END WAM CONTENT -->\r\n                \r\n                <p id=\"poweredBy\"><a
+        href=\"http://www.idoxgroup.com/\" target=\"_blank\" title=\"This link will
+        open a new window\"><img src=\"/online-applications-skin/images/idox.gif\"
+        alt=\"an Idox solution\" /></a></p>\r\n            </div>\r\n\t\t\t<div id=\"footer\">\r\n\t\t\t\t<div
+        class=\"container\">\t\t\t\t\t\r\n\t\t\t\t\t<div id=\"links\">\r\n\t\t\t\t\t\t<ul>\r\n\t\t\t\t\t\t\t<li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/Site_Map/Pages/default.aspx\">Site
+        map</a></li><li><a href=\"https://www.cardiff.gov.uk/ENG/Home/Cookies/Pages/Cookies.aspx\">Cookies</a></li><li><a
+        href=\"https://www.cardiff.gov.uk/ENG/Home/New_Disclaimer/Pages/default.aspx\">Disclaimer</a></li>\r\n\t\t\t\t\t\t</ul>\r\n\t\t\t\t\t</div>\r\n\t\t\t\t\t<div
+        class=\"clear\"></div>\r\n\t\t\t\t</div>\r\n\t\t\t</div>\r\n\t\t\t<div id=\"footerBottom\">\r\n\t\t\t
+        \   <div class=\"container\">\r\n\t\t\t        <div id=\"footercontent\"><p>&copy;
+        <script type=\"text/javascript\">document.write(new Date().getFullYear());</script>
+        Cardiff Council</p></div>\r\n\t\t\t        <div class=\"clear\"></div>\r\n\t\t\t
+        \   </div>\r\n\t\t\t</div>\r\n        </div>\r\n    </div>\r\n    <!-- IDOX
+        PA END -->\r\n\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Mon, 15 Apr 2019 11:15:43 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
This is based on work done by mySociety as part of the [MHCLG Central Register of Planning Permissions](https://www.digitalmarketplace.service.gov.uk/digital-outcomes-and-specialists/opportunities/8075) project.

It adds ability to scrape property details (UPRN, address, postcode, etc..) from Idox planning portals by adding a `.include_property` option.

This was only really intended as a quick test, to get more data to work with on our project, but maybe it might come in useful for other people too.

### Example

```ruby
pp UKPlanningScraper::Authority.named('Westminster').
                                decided_days(7).
                                include_property.
                                scrape
```

### Notes

- Commit 74e3121 isn't strictly necessary but added to make later commit diffs clearer.